### PR TITLE
add version to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added the version number to search output
 
 ## [v1.3.1] Better Errors - 2016-09-25
 - Descriptive error messages instead of exit codes

--- a/mas-cli/Commands/Search.swift
+++ b/mas-cli/Commands/Search.swift
@@ -36,7 +36,7 @@ struct SearchCommand: CommandProtocol {
             if let appName = result[ResultKeys.TrackName] as? String,
                    let appVersion = result[ResultKeys.Version] as? String,
                    let appId = result[ResultKeys.TrackId] as? Int {
-                print("\(String(appId)) \(appName) \(appVersion)")
+                print("\(String(appId)) \(appName) (\(appVersion))")
             }
         }
         

--- a/mas-cli/Commands/Search.swift
+++ b/mas-cli/Commands/Search.swift
@@ -11,6 +11,7 @@ struct ResultKeys {
     static let Results = "results"
     static let TrackName = "trackName"
     static let TrackId = "trackId"
+    static let Version = "version"
 }
 
 struct SearchCommand: CommandProtocol {
@@ -33,8 +34,9 @@ struct SearchCommand: CommandProtocol {
         
         for result in results {
             if let appName = result[ResultKeys.TrackName] as? String,
+                   let appVersion = result[ResultKeys.Version] as? String,
                    let appId = result[ResultKeys.TrackId] as? Int {
-                print("\(String(appId)) \(appName)")
+                print("\(String(appId)) \(appName) \(appVersion)")
             }
         }
         


### PR DESCRIPTION
not much more to say!

old:
```
$ mas search quip
1003160018 Quip
1002623276 Quiplash
```

new hotness:
```
$ ./mas search quip
1003160018 Quip 5.2.18
1002623276 Quiplash 1.0.0
```