### PR TITLE
👷🏻‍♀️⚠️ Re-enable danger on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
   - script/build
-  # - bundle exec danger
+  - bundle exec danger
 
 before_deploy:
   - script/package

--- a/App/main.swift
+++ b/App/main.swift
@@ -33,4 +33,3 @@ registry.register(helpCommand)
 registry.main(defaultVerb: helpCommand.verb) { error in
     printError(String(describing: error))
 }
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [v1.4.1] Stop Littering️ - 2018-02-18
+- 👷🏻‍♀️⚠️ Re-enable Danger #137
+
+## [v1.4.1] Stop Littering - 2018-02-18
 
 - 🐛 Prevent `default.profraw` from getting created #135
 


### PR DESCRIPTION
Testing that Danger works when PR is opened from a fork.

Danger token was flagged as "secure" which [excluded it from fork PRs](https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions).