### PR TITLE
🍺 Homebrew formula update for 1.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ Pods/
 Temporary Items
 bin/
 build/
+releases/
 xcuserdata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 🐛 Fixed `account` command #165
 - ✨ Added price to `search` command when `--price` flag specified #62, #148
 - 🎨 `search` output is now formatted in columns #148
+- 📺 Added simple bash completion #157
 - ➖ CocoaSeeds #155
 - ➕🍫 CocoaPods (1.5.3) #155
 - 🛠 Xcode 9.4 #153

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-## [v1.4.2] - 2018-08-12
+## [v1.4.2] - Sign-In Disabled - 2018-08-12
 
 - 🚏📥🙅🏻‍♀️ Disabled `signin` command on macOS 10.13+ #162
   - An error is immediately returned instead of crashing on newer macOS versions.

--- a/Homebrew/mas--1.4.2.high_sierra.bottle.json
+++ b/Homebrew/mas--1.4.2.high_sierra.bottle.json
@@ -1,0 +1,24 @@
+{
+    "mas": {
+        "formula": {
+            "pkg_version": "1.4.2",
+            "path": "Library/Taps/homebrew/homebrew-core/Formula/mas.rb"
+        },
+        "bottle": {
+            "root_url": "https://homebrew.bintray.com/bottles",
+            "prefix": "/usr/local",
+            "cellar": "any_skip_relocation",
+            "rebuild": 0,
+            "tags": {
+                "high_sierra": {
+                    "filename": "mas-1.4.2.high_sierra.bottle.tar.gz",
+                    "sha256": "caaea8c47a2507a9fcd2d070f5b74822d9ce2903aa39fd7adafaab0bea9a7f8e"
+                }
+            }
+        },
+        "bintray": {
+            "package": "mas",
+            "repository": "bottles"
+        }
+    }
+}

--- a/Homebrew/mas-tap.rb
+++ b/Homebrew/mas-tap.rb
@@ -26,7 +26,8 @@ class Mas < Formula
     system "bundle", "exec", "pod", "install"
 
     xcodebuild "-workspace", "mas-cli.xcworkspace",
-               "-scheme", "mas-cli Release"
+               "-scheme", "mas-cli Release",
+               "SYMROOT=build"
     bin.install "build/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"

--- a/Homebrew/mas-tap.rb
+++ b/Homebrew/mas-tap.rb
@@ -8,11 +8,11 @@ class Mas < Formula
   bottle do
     root_url "https://dl.bintray.com/phatblat/mas-bottles"
     cellar :any_skip_relocation
-    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :el_capitan
-    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :high_sierra
-    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :mojave
-    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :sierra
-    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :yosemite
+    sha256 "a99d0d7baecf45a00787365a2a078ae94068a0c63012e87f92282efb120e586e" => :el_capitan
+    sha256 "a99d0d7baecf45a00787365a2a078ae94068a0c63012e87f92282efb120e586e" => :high_sierra
+    sha256 "a99d0d7baecf45a00787365a2a078ae94068a0c63012e87f92282efb120e586e" => :mojave
+    sha256 "a99d0d7baecf45a00787365a2a078ae94068a0c63012e87f92282efb120e586e" => :sierra
+    sha256 "a99d0d7baecf45a00787365a2a078ae94068a0c63012e87f92282efb120e586e" => :yosemite
   end
 
   depends_on :xcode => ["9.0", :build]

--- a/Homebrew/mas-tap.rb
+++ b/Homebrew/mas-tap.rb
@@ -15,9 +15,17 @@ class Mas < Formula
     sha256 "a99d0d7baecf45a00787365a2a078ae94068a0c63012e87f92282efb120e586e" => :yosemite
   end
 
-  depends_on :xcode => ["9.0", :build]
+  depends_on :xcode => ["9.3", :build]
+
+  resource "cocoapods" do
+    url "https://dl.bintray.com/phatblat/mas-bottles/master.tar.gz"
+    sha256 "fd8f1b06a2a0276c9005241b45cc19393b7c39cfc91d08da92a307ea2416e966"
+  end
 
   def install
+    # Pre-install a shallow copy of the CocoaPods master repo
+    (buildpath/".brew_home/.cocoapods/repos/master").install resource("cocoapods")
+
     # Install bundler, then use it to install gems used by project
     ENV["GEM_HOME"] = buildpath/"gem_home"
     system "gem", "install", "bundler"
@@ -27,8 +35,9 @@ class Mas < Formula
 
     xcodebuild "-workspace", "mas-cli.xcworkspace",
                "-scheme", "mas-cli Release",
-               "SYMROOT=build"
-    bin.install "build/mas"
+               "SYMROOT=#{buildpath.realpath}"
+
+    bin.install buildpath/"build/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"
   end

--- a/Homebrew/mas-tap.rb
+++ b/Homebrew/mas-tap.rb
@@ -1,0 +1,38 @@
+class Mas < Formula
+  desc "Mac App Store command-line interface"
+  homepage "https://github.com/mas-cli/mas"
+  url "https://github.com/mas-cli/mas/archive/v1.4.2.tar.gz"
+  sha256 "f9a751ff84e6dcbaedd4b2ca95b3ca623c739fd3af0b6ca950c321f2ce840bfe"
+  head "https://github.com/mas-cli/mas.git"
+
+  bottle do
+    root_url "https://dl.bintray.com/phatblat/mas-bottles"
+    cellar :any_skip_relocation
+    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :el_capitan
+    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :high_sierra
+    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :mojave
+    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :sierra
+    sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :yosemite
+  end
+
+  depends_on :xcode => ["9.0", :build]
+
+  def install
+    # Install bundler, then use it to install gems used by project
+    ENV["GEM_HOME"] = buildpath/"gem_home"
+    system "gem", "install", "bundler"
+    ENV.prepend_path "PATH", buildpath/"gem_home/bin"
+    system "bundle", "install"
+    system "bundle", "exec", "pod", "install"
+
+    xcodebuild "-workspace", "mas-cli.xcworkspace",
+               "-scheme", "mas-cli Release"
+    bin.install "build/mas"
+
+    bash_completion.install "contrib/completion/mas-completion.bash" => "mas"
+  end
+
+  test do
+    assert_equal version.to_s, shell_output("#{bin}/mas version").chomp
+  end
+end

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -1,8 +1,8 @@
 class Mas < Formula
   desc "Mac App Store command-line interface"
   homepage "https://github.com/mas-cli/mas"
-  url "https://github.com/mas-cli/mas/archive/v1.4.1.tar.gz"
-  sha256 "4fd91c13b46d403b52dbee3891adb3cd6571e07ad20cf58de0100c9f695e6c24"
+  url "https://github.com/mas-cli/mas/archive/v1.4.2.tar.gz"
+  sha256 "f9a751ff84e6dcbaedd4b2ca95b3ca623c739fd3af0b6ca950c321f2ce840bfe"
   head "https://github.com/mas-cli/mas.git"
 
   bottle do

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -11,12 +11,16 @@ class Mas < Formula
     sha256 "af5be6aa9902d9cfc2aa69dbf313441a7c201463d516face721f900ceae9556b" => :sierra
   end
 
-  depends_on :xcode => ["9.0", :build]
-  depends_on "ruby" => :build if MacOS.version <= :sierra
+  depends_on :xcode => ["9.3", :build]
+
+  resource "cocoapods" do
+    url "https://dl.bintray.com/phatblat/mas-bottles/master.tar.gz"
+    sha256 "fd8f1b06a2a0276c9005241b45cc19393b7c39cfc91d08da92a307ea2416e966"
+  end
 
   def install
     # Pre-install a shallow copy of the CocoaPods master repo
-    system "git", "clone", "--depth", "1", "https://github.com/CocoaPods/Specs.git", File.expand_path("~/.cocoapods/repos/master")
+    (buildpath/".brew_home/.cocoapods/repos/master").install resource("cocoapods")
 
     # Install bundler, then use it to install gems used by project
     ENV["GEM_HOME"] = buildpath/"gem_home"

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -29,6 +29,17 @@ class Mas < Formula
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"
   end
 
+  def caveats; <<~EOS
+    This core formula cannot be built on macOS 10.11 or older.
+
+    Bottles for all supported macOS versions can be found on our custom tap:
+
+    brew tap mas-cli/tap && brew tap-pin mas-cli/tap
+
+    https://github.com/mas-cli/homebrew-tap
+  EOS
+  end
+
   test do
     assert_equal version.to_s, shell_output("#{bin}/mas version").chomp
   end

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -14,10 +14,15 @@ class Mas < Formula
   depends_on :xcode => ["9.0", :build]
 
   def install
-    xcodebuild "-project", "mas-cli.xcodeproj",
-               "-scheme", "mas-cli Release",
-               "-configuration", "Release",
-               "SYMROOT=build"
+    # Install bundler, then use it to install gems used by project
+    ENV["GEM_HOME"] = buildpath/"gem_home"
+    system "gem", "install", "bundler"
+    ENV.prepend_path "PATH", buildpath/"gem_home/bin"
+    system "bundle", "install"
+    system "bundle", "exec", "pod", "install"
+
+    xcodebuild "-workspace", "mas-cli.xcworkspace",
+               "-scheme", "mas-cli Release"
     bin.install "build/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -12,8 +12,12 @@ class Mas < Formula
   end
 
   depends_on :xcode => ["9.0", :build]
+  depends_on "ruby" => :build if MacOS.version <= :sierra
 
   def install
+    # Pre-install a shallow copy of the CocoaPods master repo
+    system "git", "clone", "--depth", "1", "https://github.com/CocoaPods/Specs.git", File.expand_path("~/.cocoapods/repos/master")
+
     # Install bundler, then use it to install gems used by project
     ENV["GEM_HOME"] = buildpath/"gem_home"
     system "gem", "install", "bundler"
@@ -23,21 +27,11 @@ class Mas < Formula
 
     xcodebuild "-workspace", "mas-cli.xcworkspace",
                "-scheme", "mas-cli Release",
-               "SYMROOT=build"
-    bin.install "build/mas"
+               "SYMROOT=#{buildpath.realpath}"
+
+    bin.install buildpath/"build/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"
-  end
-
-  def caveats; <<~EOS
-    This core formula cannot be built on macOS 10.11 or older.
-
-    Bottles for all supported macOS versions can be found on our custom tap:
-
-    brew tap mas-cli/tap && brew tap-pin mas-cli/tap
-
-    https://github.com/mas-cli/homebrew-tap
-  EOS
   end
 
   test do

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -22,7 +22,8 @@ class Mas < Formula
     system "bundle", "exec", "pod", "install"
 
     xcodebuild "-workspace", "mas-cli.xcworkspace",
-               "-scheme", "mas-cli Release"
+               "-scheme", "mas-cli Release",
+               "SYMROOT=build"
     bin.install "build/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"

--- a/README.md
+++ b/README.md
@@ -16,12 +16,9 @@ A simple command line interface for the Mac App Store. Designed for scripting an
 
 ### ☎️ Older macOS Versions
 
-Macs running macOS 10.11 (El Capitan) or lower will not be able to install mas from the default homebrew-core tap.
-This project requires at least macOS 10.12 to build and Homebrew does not provide bottles for versions older
-than the minimum supported by the project.
-
-We provide a [custom tap](https://github.com/mas-cli/homebrew-tap) with pre-built bottles for all macOS versions
-since 10.9 (the Xcode project deployment target).
+macOS 10.13 (High Sierra) is required to install mas from the core Homebrew formula.
+We provide a [custom Homebrew tap](https://github.com/mas-cli/homebrew-tap) with pre-built bottles
+for all macOS versions since 10.9.
 
 #### 😴 TL;DR
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A simple command line interface for the Mac App Store. Designed for scripting an
 
 [![Build Status](https://travis-ci.org/mas-cli/mas.svg?branch=master)](https://travis-ci.org/mas-cli/mas)
 
-## Install
+## 📲 Install
+
+### 🍺 Homebrew
 
 [Homebrew](http://brew.sh) is the preferred way to install:
 
@@ -80,7 +82,7 @@ Updates can be performed selectively by providing the app identifier(s) to
     ==> Downloading Xcode
     ==> Installed Xcode
 
-### Signin
+### 🚏📥 Sign-in
 
 To sign into the Mac App Store for the first time run `mas signin`.
 
@@ -104,19 +106,19 @@ You can also embed your password in the command.
 
 Use `mas signout` to sign out from the Mac App Store.
 
-## Homebrew integration
+## 🍺 Homebrew integration
 
 `mas` is integrated with [homebrew-bundle](https://github.com/Homebrew/homebrew-bundle). If `mas` is installed, and you run `brew bundle dump`,
 then your Mac App Store apps will be included in the Brewfile created. See the [homebrew-bundle](https://github.com/Homebrew/homebrew-bundle)
 docs for more details.
 
-## When something doesn't work
+## 💥 When something doesn't work
 
 If you see the error "This redownload is not available for this Apple ID either because it was bought by a different user of the item was refunded or cancelled.", it's probably because you haven't installed the app through the App Store yet. See [#46](https://github.com/mas-cli/mas/issues/46#issuecomment-248581233).
 
 If `mas` doesn't work for you as expected (e.g. you can't update/download apps), run `mas reset` and try again. If the issue persists, please [file a bug](https://github.com/mas-cli/mas/issues/new)! All your feedback is much appreciated ✨
 
-## Using `tmux`
+## 📺 Using `tmux`
 
 `mas` operates via the same system services as the Mac App Store. These exist as
 separate processes with communication through XPC. As a result of this, `mas`
@@ -132,7 +134,7 @@ $ brew install reattach-to-user-namespace
 $ reattach-to-user-namespace mas install
 ```
 
-## Build from source
+## ℹ️ Build from source
 
 You can now build from Xcode by opening `mas-cli.xcodeproj`, or from the Terminal:
 
@@ -154,7 +156,7 @@ The tests in this project are a work-in-progress. Since Xcode does not officiall
 
 We may move the app code into a framework target to make it easier to test.
 
-## License
+## 📄 License
 
 mas-cli was created by [@argon](https://github.com/argon).
 Code is under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -14,9 +14,30 @@ A simple command line interface for the Mac App Store. Designed for scripting an
 
     brew install mas
 
+### ☎️ Older macOS Versions
+
+Macs running macOS 10.11 (El Capitan) or lower will not be able to install mas from the default homebrew-core tap.
+This project requires at least macOS 10.12 to build and Homebrew does not provide bottles for versions older
+than the minimum supported by the project.
+
+We provide a [custom tap](https://github.com/mas-cli/homebrew-tap) with pre-built bottles for all macOS versions
+since 10.9 (the Xcode project deployment target).
+
+#### 😴 TL;DR
+
+Just run these commands:
+
+```
+$ brew tap mas-cli/tap
+$ brew tap-pin mas-cli/tap
+$ brew install mas
+```
+
+### 🐙 GitHub Releases
+
 Alternatively, binaries are available in the [GitHub Releases](https://github.com/mas-cli/mas/releases)
 
-## Usage
+## 🤳🏻 Usage
 
 Each application in the Mac App Store has a product identifier which is also
 used for mas-cli commands. Using `mas list` will show all installed


### PR DESCRIPTION
Changes to the `install` function to fetch bundler and run the `pod install` command. Thank goodness for the [`swiftgen`](https://github.com/Homebrew/homebrew-core/blob/d3e8bb0dfdf5c3ed4a4a72645805290169b88c66/Formula/swiftgen.rb#L21-L26) formula because I don't know if I could have figured that out.

New formula updated in Homebrew/homebrew-core#31058