### PR TITLE
👐🏻 Open AppStore.app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- 👐🏻 Open AppStore.app with just `mas open` #200
 - ♻️🌐 Network refactor #198
 - 👷🏻‍♀️ Jenkins Pipeline #197
 - ✨ New `home`, `open` and `vendor` commands #196

--- a/MasKitTests/Commands/OpenCommandSpec.swift
+++ b/MasKitTests/Commands/OpenCommandSpec.swift
@@ -48,6 +48,16 @@ class OpenCommandSpec: QuickSpec {
                 expect(url).toNot(beNil())
                 expect(url?.scheme) == "macappstore"
             }
+            it("just opens MAS if no app specified") {
+                storeSearch.apps[result.trackId] = result
+
+                let cmdResult = cmd.run(OpenCommand.Options(appId: nil))
+                expect(cmdResult).to(beSuccess())
+                expect(openCommand.arguments).toNot(beNil())
+                let url = URL(string: openCommand.arguments!.first!)
+                expect(url).toNot(beNil())
+                expect(url) == URL(string: "macappstore://")
+            }
         }
     }
 }

--- a/MasKitTests/Commands/OpenCommandSpec.swift
+++ b/MasKitTests/Commands/OpenCommandSpec.swift
@@ -49,9 +49,7 @@ class OpenCommandSpec: QuickSpec {
                 expect(url?.scheme) == "macappstore"
             }
             it("just opens MAS if no app specified") {
-                storeSearch.apps[result.trackId] = result
-
-                let cmdResult = cmd.run(OpenCommand.Options(appId: nil))
+                let cmdResult = cmd.run(OpenCommand.Options(appId: "appstore"))
                 expect(cmdResult).to(beSuccess())
                 expect(openCommand.arguments).toNot(beNil())
                 let url = URL(string: openCommand.arguments!.first!)

--- a/script/uninstall
+++ b/script/uninstall
@@ -2,7 +2,7 @@
 
 PREFIX=/usr/local
 
-echo "==> 🔥 Installing mas"
+echo "==> 🔥 Uninstalling mas"
 
-rm -rf /usr/local/Frameworks/MasKit.framework
-rm -f /usr/local/bin/mas
+trash /usr/local/Frameworks/MasKit.framework
+trash /usr/local/bin/mas


### PR DESCRIPTION
Building on #196, I thought it would be handy to use `mas open` without any further arguments to simply open the AppStore.app.

~~However, I'm not sure it's possible to make the appId argument optional through Commandant.~~

```
$ mas open
Missing argument for the app id
```

Ended up using a marker value of "appstore" so the following two commands are equivalent:

```
$ mas open
$ mas open appstore
```