### PR TITLE
🐛 Restore search table output

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,9 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
+**Actual behavior**
+A clear and concise description of what actually happened.
+
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 

--- a/.hound.yml
+++ b/.hound.yml
@@ -5,13 +5,12 @@
 # http://help.houndci.com/configuration/swiftlint
 #
 ---
-excluded:
-- Carthage/
-- docs/
-- MasKitTests/
-
+fail_on_violations: true
 erblint:
   enabled: false
-
+shellcheck:
+  enabled: true
+  config_file: .shellcheck.yml
 swiftlint:
+  enabled: true
   config_file: .swiftlint.yml

--- a/.hound.yml
+++ b/.hound.yml
@@ -5,6 +5,11 @@
 # http://help.houndci.com/configuration/swiftlint
 #
 ---
+excluded:
+- Carthage/
+- docs/
+- MasKitTests/
+
 erblint:
   enabled: false
 

--- a/.hound.yml
+++ b/.hound.yml
@@ -5,12 +5,15 @@
 # http://help.houndci.com/configuration/swiftlint
 #
 ---
-fail_on_violations: true
+fail_on_violations: false
+
 erblint:
   enabled: false
+
 shellcheck:
   enabled: true
   config_file: .shellcheck.yml
+
 swiftlint:
   enabled: true
   config_file: .swiftlint.yml

--- a/.shellcheck.yml
+++ b/.shellcheck.yml
@@ -1,0 +1,8 @@
+#
+# .shellcheck.yml
+# mas-cli
+#
+#
+---
+exclude:
+  - script/sort.pl

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
 brew "carthage"
+brew "shellcheck"
 brew "swiftlint"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-
+- 🐛 Restore search table output #205
 
 ## [v1.6.0] 🔗 Links - 2019-01-12
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,13 +1,22 @@
+#!/usr/bin/env ruby
+#
+# Dangerfile
+# mas-cli
+#
+# https://danger.systems/guides/dangerfile.html
+#
+
 # Sometimes it's a README fix, or something like that - which isn't relevant for
 # including in a project's CHANGELOG for example
-has_app_changes = !git.modified_files.grep(/App/).empty?
-# has_test_changes = !git.modified_files.grep(/AppTests/).empty?
+has_app_changes = !git.modified_files.grep(/MasKit/).empty?
+has_test_changes = !git.modified_files.grep(/MasKitTests/).empty?
 
 is_version_bump = git.modified_files.sort == [
-    "App/mas-cli-Info.plist",
-    "AppTests/Info.plist",
     "CHANGELOG.md",
-    "mas-cli.xcodeproj/project.pbxproj"
+    "mas/mas-Info.plist",
+    "mas-cli.xcodeproj/project.pbxproj",
+    "MasKit/SupportingFiles/Info.plist",
+    "MasKitTests/SupportingFiles/Info.plist"
 ].sort
 message(":bookmark: Version bump!") if is_version_bump
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.11.0)
+    danger (5.11.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)

--- a/MasKit/Formatters/SearchResultFormatter.swift
+++ b/MasKit/Formatters/SearchResultFormatter.swift
@@ -28,12 +28,12 @@ struct SearchResultFormatter {
             let price = result.price
 
             if includePrice {
-                output += String(format: "%12d  %@  $%5.2f  (%@)", appId, appName, price, version)
+                output += String(format: "%12d  %@  $%5.2f  (%@)\n", appId, appName, price, version)
             } else {
-                output += String(format: "%12d  %@ (%@)", appId, appName, version)
+                output += String(format: "%12d  %@ (%@)\n", appId, appName, version)
             }
         }
 
-        return output
+        return output.trimmingCharacters(in: .newlines)
     }
 }

--- a/MasKitTests/Formatters/SearchResultFormatterSpec.swift
+++ b/MasKitTests/Formatters/SearchResultFormatterSpec.swift
@@ -1,0 +1,87 @@
+//
+//  SearchResultFormatterSpec.swift
+//  MasKitTests
+//
+//  Created by Ben Chatelain on 1/14/19.
+//  Copyright © 2019 mas-cli. All rights reserved.
+//
+
+@testable import MasKit
+import Result
+import Quick
+import Nimble
+
+class SearchResultsFormatterSpec: QuickSpec {
+    override func spec() {
+        // static func reference
+        let format = SearchResultFormatter.format(results:includePrice:)
+        var results: [SearchResult] = []
+
+        describe("search results formatter") {
+            beforeEach {
+                results = []
+            }
+            it("formats nothing as empty string") {
+                let output = format(results, false)
+                expect(output) == ""
+            }
+            it("can format a single result") {
+                results = [SearchResult(
+                    price: 9.87,
+                    trackId: 12345,
+                    trackName: "Awesome App",
+                    version: "19.2.1"
+                )]
+                let output = format(results, false)
+                expect(output) == "       12345  Awesome App (19.2.1)"
+            }
+            it("can format a single result with price") {
+                results = [SearchResult(
+                    price: 9.87,
+                    trackId: 12345,
+                    trackName: "Awesome App",
+                    version: "19.2.1"
+                )]
+                let output = format(results, true)
+                expect(output) == "       12345  Awesome App  $ 9.87  (19.2.1)"
+            }
+            it("can format a two results") {
+                results = [
+                    SearchResult(
+                        price: 9.87,
+                        trackId: 12345,
+                        trackName: "Awesome App",
+                        version: "19.2.1"
+                    ),
+                    SearchResult(
+                        price: 0.01,
+                        trackId: 67890,
+                        trackName: "Even Better App",
+                        version: "1.2.0"
+                    )
+                ]
+                let output = format(results, false)
+                expect(output) == "       12345  Awesome App     (19.2.1)\n       67890  Even Better App (1.2.0)"
+            }
+            it("can format a two results with prices") {
+                results = [
+                    SearchResult(
+                        price: 9.87,
+                        trackId: 12345,
+                        trackName: "Awesome App",
+                        version: "19.2.1"
+                    ),
+                    SearchResult(
+                        price: 0.01,
+                        trackId: 67890,
+                        trackName: "Even Better App",
+                        version: "1.2.0"
+                    )
+                ]
+                let output = format(results, true)
+                expect(output) == "       12345  Awesome App      $ 9.87  (19.2.1)\n       67890  Even Better App  $ 0.01  (1.2.0)"
+            }
+        }
+    }
+}
+

--- a/MasKitTests/Formatters/SearchResultFormatterSpec.swift
+++ b/MasKitTests/Formatters/SearchResultFormatterSpec.swift
@@ -61,7 +61,8 @@ class SearchResultsFormatterSpec: QuickSpec {
                     )
                 ]
                 let output = format(results, false)
-                expect(output) == "       12345  Awesome App     (19.2.1)\n       67890  Even Better App (1.2.0)"
+                expect(output) ==
+                    "       12345  Awesome App     (19.2.1)\n       67890  Even Better App (1.2.0)"
             }
             it("can format a two results with prices") {
                 results = [
@@ -79,9 +80,9 @@ class SearchResultsFormatterSpec: QuickSpec {
                     )
                 ]
                 let output = format(results, true)
-                expect(output) == "       12345  Awesome App      $ 9.87  (19.2.1)\n       67890  Even Better App  $ 0.01  (1.2.0)"
+                expect(output) ==
+                    "       12345  Awesome App      $ 9.87  (19.2.1)\n       67890  Even Better App  $ 0.01  (1.2.0)"
             }
         }
     }
 }
-

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -974,7 +974,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if test -n \"$JENKINS_URL\"\nthen\n    echo \"Skipping SwiftLint run script on CI, will run in Lint stage.\"\n    return\nfi\n\nif which -s swiftlint; then\n    swiftlint lint --quiet\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "script/swiftlint_runscript\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -236,6 +236,8 @@
 		B55B3D9821EEA6AA0009A1A5 /* .ruby-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".ruby-version"; sourceTree = "<group>"; };
 		B55B3D9921EEA6AA0009A1A5 /* .bundle */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .bundle; sourceTree = "<group>"; };
 		B55B3D9A21EEA6AA0009A1A5 /* .editorconfig */ = {isa = PBXFileReference; lastKnownFileType = text; path = .editorconfig; sourceTree = "<group>"; };
+		B55B3D9B21EEBD6E0009A1A5 /* .shellcheck.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .shellcheck.yml; sourceTree = "<group>"; };
+		B55B3D9D21EEBD7D0009A1A5 /* .envrc */ = {isa = PBXFileReference; lastKnownFileType = text; path = .envrc; sourceTree = "<group>"; };
 		B576FDF221E03B780016B39D /* MasStoreSearchSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasStoreSearchSpec.swift; sourceTree = "<group>"; };
 		B576FDF421E1078F0016B39D /* MASErrorTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MASErrorTestCase.swift; sourceTree = "<group>"; };
 		B576FDF621E107AA0016B39D /* OpenSystemCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSystemCommand.swift; sourceTree = "<group>"; };
@@ -403,10 +405,12 @@
 			children = (
 				B55B3D9921EEA6AA0009A1A5 /* .bundle */,
 				B55B3D9A21EEA6AA0009A1A5 /* .editorconfig */,
+				B55B3D9D21EEBD7D0009A1A5 /* .envrc */,
 				B55B3D9721EEA6AA0009A1A5 /* .github */,
 				B55B3D9321EEA6A90009A1A5 /* .gitignore */,
 				B55B3D9421EEA6A90009A1A5 /* .hound.yml */,
 				B55B3D9821EEA6AA0009A1A5 /* .ruby-version */,
+				B55B3D9B21EEBD6E0009A1A5 /* .shellcheck.yml */,
 				B55B3D9521EEA6AA0009A1A5 /* .swiftlint.yml */,
 				B55B3D9621EEA6AA0009A1A5 /* .travis.yml */,
 				B55B3D8C21ED96FD0009A1A5 /* bin */,

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		B555292F219A219100ACB4CA /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90CB406C213F4DDD0044E445 /* Nimble.framework */; };
 		B5552936219A23FF00ACB4CA /* Nimble.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = 90CB406C213F4DDD0044E445 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B5552937219A23FF00ACB4CA /* Quick.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = 90CB406A213F4DDD0044E445 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B55B3D9221ED9B8C0009A1A5 /* SearchResultFormatterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55B3D9121ED9B8C0009A1A5 /* SearchResultFormatterSpec.swift */; };
 		B576FDF321E03B780016B39D /* MasStoreSearchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576FDF221E03B780016B39D /* MasStoreSearchSpec.swift */; };
 		B576FDF521E1078F0016B39D /* MASErrorTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576FDF421E1078F0016B39D /* MASErrorTestCase.swift */; };
 		B576FDF721E107AA0016B39D /* OpenSystemCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576FDF621E107AA0016B39D /* OpenSystemCommand.swift */; };
@@ -226,6 +227,7 @@
 		B55B3D8D21ED96FD0009A1A5 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		B55B3D8E21ED96FD0009A1A5 /* Package */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Package; sourceTree = "<group>"; };
 		B55B3D8F21ED96FD0009A1A5 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		B55B3D9121ED9B8C0009A1A5 /* SearchResultFormatterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultFormatterSpec.swift; sourceTree = "<group>"; };
 		B576FDF221E03B780016B39D /* MasStoreSearchSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasStoreSearchSpec.swift; sourceTree = "<group>"; };
 		B576FDF421E1078F0016B39D /* MASErrorTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MASErrorTestCase.swift; sourceTree = "<group>"; };
 		B576FDF621E107AA0016B39D /* OpenSystemCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSystemCommand.swift; sourceTree = "<group>"; };
@@ -416,6 +418,14 @@
 				B55B3D8521ED96FD0009A1A5 /* script */,
 			);
 			name = Project;
+			sourceTree = "<group>";
+		};
+		B55B3D9021ED9B6A0009A1A5 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				B55B3D9121ED9B8C0009A1A5 /* SearchResultFormatterSpec.swift */,
+			);
+			path = Formatters;
 			sourceTree = "<group>";
 		};
 		B576FE0921E114BD0016B39D /* Network */ = {
@@ -696,6 +706,7 @@
 				B576FE2421E29CE80016B39D /* Errors */,
 				B576FE1921E28E530016B39D /* Extensions */,
 				B576FE1721E28E1F0016B39D /* ExternalCommands */,
+				B55B3D9021ED9B6A0009A1A5 /* Formatters */,
 				B5793E28219BDD4800135B39 /* JSON */,
 				B594B12C21D584E800F3AC59 /* Models */,
 				B576FE0A21E116470016B39D /* Network */,
@@ -1021,6 +1032,7 @@
 				B576FDF321E03B780016B39D /* MasStoreSearchSpec.swift in Sources */,
 				B576FE0C21E116590016B39D /* NetworkManagerTests.swift in Sources */,
 				B576FE1B21E28E8A0016B39D /* NetworkSessionMock.swift in Sources */,
+				B55B3D9221ED9B8C0009A1A5 /* SearchResultFormatterSpec.swift in Sources */,
 				B576FE2C21E42A230016B39D /* OutputListener.swift in Sources */,
 				B576FE1221E1D82D0016B39D /* NetworkSessionMockFromFile.swift in Sources */,
 				B5DBF81321DEEC7C00F3B151 /* OpenCommandSpec.swift in Sources */,

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -228,6 +228,14 @@
 		B55B3D8E21ED96FD0009A1A5 /* Package */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Package; sourceTree = "<group>"; };
 		B55B3D8F21ED96FD0009A1A5 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B55B3D9121ED9B8C0009A1A5 /* SearchResultFormatterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultFormatterSpec.swift; sourceTree = "<group>"; };
+		B55B3D9321EEA6A90009A1A5 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		B55B3D9421EEA6A90009A1A5 /* .hound.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .hound.yml; sourceTree = "<group>"; };
+		B55B3D9521EEA6AA0009A1A5 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
+		B55B3D9621EEA6AA0009A1A5 /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
+		B55B3D9721EEA6AA0009A1A5 /* .github */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .github; sourceTree = "<group>"; };
+		B55B3D9821EEA6AA0009A1A5 /* .ruby-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".ruby-version"; sourceTree = "<group>"; };
+		B55B3D9921EEA6AA0009A1A5 /* .bundle */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .bundle; sourceTree = "<group>"; };
+		B55B3D9A21EEA6AA0009A1A5 /* .editorconfig */ = {isa = PBXFileReference; lastKnownFileType = text; path = .editorconfig; sourceTree = "<group>"; };
 		B576FDF221E03B780016B39D /* MasStoreSearchSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasStoreSearchSpec.swift; sourceTree = "<group>"; };
 		B576FDF421E1078F0016B39D /* MASErrorTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MASErrorTestCase.swift; sourceTree = "<group>"; };
 		B576FDF621E107AA0016B39D /* OpenSystemCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSystemCommand.swift; sourceTree = "<group>"; };
@@ -393,6 +401,14 @@
 		B55B3D7821ED96AA0009A1A5 /* Project */ = {
 			isa = PBXGroup;
 			children = (
+				B55B3D9921EEA6AA0009A1A5 /* .bundle */,
+				B55B3D9A21EEA6AA0009A1A5 /* .editorconfig */,
+				B55B3D9721EEA6AA0009A1A5 /* .github */,
+				B55B3D9321EEA6A90009A1A5 /* .gitignore */,
+				B55B3D9421EEA6A90009A1A5 /* .hound.yml */,
+				B55B3D9821EEA6AA0009A1A5 /* .ruby-version */,
+				B55B3D9521EEA6AA0009A1A5 /* .swiftlint.yml */,
+				B55B3D9621EEA6AA0009A1A5 /* .travis.yml */,
 				B55B3D8C21ED96FD0009A1A5 /* bin */,
 				B55B3D8B21ED96FD0009A1A5 /* Brewfile */,
 				B55B3D8721ED96FD0009A1A5 /* build */,

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -203,6 +203,29 @@
 		90CB406A213F4DDD0044E445 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = "<group>"; };
 		90CB406B213F4DDD0044E445 /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = "<group>"; };
 		90CB406C213F4DDD0044E445 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = "<group>"; };
+		B55B3D7921ED96FC0009A1A5 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
+		B55B3D7A21ED96FC0009A1A5 /* CODE_OF_CONDUCT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CODE_OF_CONDUCT.md; sourceTree = "<group>"; };
+		B55B3D7B21ED96FC0009A1A5 /* Dangerfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Dangerfile; sourceTree = "<group>"; };
+		B55B3D7C21ED96FC0009A1A5 /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
+		B55B3D7D21ED96FC0009A1A5 /* releases */ = {isa = PBXFileReference; lastKnownFileType = folder; path = releases; sourceTree = "<group>"; };
+		B55B3D7E21ED96FD0009A1A5 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docs; sourceTree = "<group>"; };
+		B55B3D7F21ED96FD0009A1A5 /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
+		B55B3D8021ED96FD0009A1A5 /* Carthage */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Carthage; sourceTree = "<group>"; };
+		B55B3D8121ED96FD0009A1A5 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
+		B55B3D8221ED96FD0009A1A5 /* Gemfile.lock */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile.lock; sourceTree = "<group>"; };
+		B55B3D8321ED96FD0009A1A5 /* contrib */ = {isa = PBXFileReference; lastKnownFileType = folder; path = contrib; sourceTree = "<group>"; };
+		B55B3D8421ED96FD0009A1A5 /* Homebrew */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Homebrew; sourceTree = "<group>"; };
+		B55B3D8521ED96FD0009A1A5 /* script */ = {isa = PBXFileReference; lastKnownFileType = folder; path = script; sourceTree = "<group>"; };
+		B55B3D8621ED96FD0009A1A5 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		B55B3D8721ED96FD0009A1A5 /* build */ = {isa = PBXFileReference; lastKnownFileType = folder; path = build; sourceTree = "<group>"; };
+		B55B3D8821ED96FD0009A1A5 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		B55B3D8921ED96FD0009A1A5 /* Jenkinsfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Jenkinsfile; sourceTree = "<group>"; };
+		B55B3D8A21ED96FD0009A1A5 /* mas-cli.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "mas-cli.png"; sourceTree = "<group>"; };
+		B55B3D8B21ED96FD0009A1A5 /* Brewfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Brewfile; sourceTree = "<group>"; };
+		B55B3D8C21ED96FD0009A1A5 /* bin */ = {isa = PBXFileReference; lastKnownFileType = folder; path = bin; sourceTree = "<group>"; };
+		B55B3D8D21ED96FD0009A1A5 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		B55B3D8E21ED96FD0009A1A5 /* Package */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Package; sourceTree = "<group>"; };
+		B55B3D8F21ED96FD0009A1A5 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B576FDF221E03B780016B39D /* MasStoreSearchSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasStoreSearchSpec.swift; sourceTree = "<group>"; };
 		B576FDF421E1078F0016B39D /* MASErrorTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MASErrorTestCase.swift; sourceTree = "<group>"; };
 		B576FDF621E107AA0016B39D /* OpenSystemCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSystemCommand.swift; sourceTree = "<group>"; };
@@ -363,6 +386,36 @@
 			);
 			name = Carthage;
 			path = Carthage/Build/Mac;
+			sourceTree = "<group>";
+		};
+		B55B3D7821ED96AA0009A1A5 /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				B55B3D8C21ED96FD0009A1A5 /* bin */,
+				B55B3D8B21ED96FD0009A1A5 /* Brewfile */,
+				B55B3D8721ED96FD0009A1A5 /* build */,
+				B55B3D8121ED96FD0009A1A5 /* Cartfile */,
+				B55B3D7C21ED96FC0009A1A5 /* Cartfile.private */,
+				B55B3D7921ED96FC0009A1A5 /* Cartfile.resolved */,
+				B55B3D8021ED96FD0009A1A5 /* Carthage */,
+				B55B3D8D21ED96FD0009A1A5 /* CHANGELOG.md */,
+				B55B3D7A21ED96FC0009A1A5 /* CODE_OF_CONDUCT.md */,
+				B55B3D8321ED96FD0009A1A5 /* contrib */,
+				B55B3D8821ED96FD0009A1A5 /* CONTRIBUTING.md */,
+				B55B3D7B21ED96FC0009A1A5 /* Dangerfile */,
+				B55B3D7E21ED96FD0009A1A5 /* docs */,
+				B55B3D7F21ED96FD0009A1A5 /* Gemfile */,
+				B55B3D8221ED96FD0009A1A5 /* Gemfile.lock */,
+				B55B3D8421ED96FD0009A1A5 /* Homebrew */,
+				B55B3D8921ED96FD0009A1A5 /* Jenkinsfile */,
+				B55B3D8621ED96FD0009A1A5 /* LICENSE */,
+				B55B3D8A21ED96FD0009A1A5 /* mas-cli.png */,
+				B55B3D8E21ED96FD0009A1A5 /* Package */,
+				B55B3D8F21ED96FD0009A1A5 /* README.md */,
+				B55B3D7D21ED96FC0009A1A5 /* releases */,
+				B55B3D8521ED96FD0009A1A5 /* script */,
+			);
+			name = Project;
 			sourceTree = "<group>";
 		};
 		B576FE0921E114BD0016B39D /* Network */ = {
@@ -549,6 +602,7 @@
 				F8FB715E20F2B41400F56FDC /* MasKitTests */,
 				F8FB719920F2EC4500F56FDC /* PrivateFrameworks */,
 				ED031A791B5127C00097692E /* Products */,
+				B55B3D7821ED96AA0009A1A5 /* Project */,
 			);
 			sourceTree = "<group>";
 		};

--- a/mas.xcworkspace/contents.xcworkspacedata
+++ b/mas.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:">
-   </FileRef>
-   <FileRef
       location = "container:mas-cli.xcodeproj">
    </FileRef>
 </Workspace>

--- a/script/build
+++ b/script/build
@@ -43,7 +43,7 @@ build() {
 }
 
 archive() {
-  echo "==> 📦 Archiving  ($VERSION)"
+  echo "==> 📦 Archiving mas ($VERSION)"
   set -o pipefail && \
       xcodebuild -project "$PROJECT" \
           -scheme "$SCHEME" \

--- a/script/lint
+++ b/script/lint
@@ -2,4 +2,13 @@
 
 echo "==> 🚨 Linting mas"
 
+echo
+echo "--> 🕊️ Swift"
 swiftlint lint --strict
+
+echo
+echo "--> 📜 Bash"
+shopt -s extglob
+# Only lint files with no extension (skipping .pl)
+shellcheck --shell=bash script/!(*.*)
+shopt -u extglob

--- a/script/lint
+++ b/script/lint
@@ -1,4 +1,10 @@
 #!/bin/bash -e
+#
+# script/lint
+# mas-cli
+#
+# Linting checks for CI "Lint" stage.
+#
 
 echo "==> 🚨 Linting mas"
 

--- a/script/package
+++ b/script/package
@@ -16,7 +16,7 @@ DISTRIBUTION_PLIST="Package/Distribution.plist"
 # Destination for `xcodebuild install`
 # DSTROOT will be updated if unset.
 INSTALL_TEMPORARY_FOLDER=${DSTROOT:-build/distributions}
-mkdir -p $INSTALL_TEMPORARY_FOLDER
+mkdir -p "$INSTALL_TEMPORARY_FOLDER"
 
 VERSION=$(script/version)
 

--- a/script/swiftlint_runscript
+++ b/script/swiftlint_runscript
@@ -9,7 +9,7 @@
 if test -n "$JENKINS_URL"
 then
     echo "Skipping SwiftLint run script on CI, will run in Lint stage."
-    return
+    exit
 fi
 
 # 😕 When run from Xcode, the command command doesn't support these options

--- a/script/swiftlint_runscript
+++ b/script/swiftlint_runscript
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+#
+# script/swiftlint_runscript
+# mas-cli
+#
+# SwiftLint invocation from inside Xcode. Minimal output.
+#
+
+if test -n "$JENKINS_URL"
+then
+    echo "Skipping SwiftLint run script on CI, will run in Lint stage."
+    return
+fi
+
+# 😕 When run from Xcode, the command command doesn't support these options
+# command --quiet --search swiftlint
+# : command: --: invalid option
+# : command: usage: command [-pVv] command [arg ...]
+
+
+if command -v swiftlint > /dev/null; then
+    swiftlint lint --quiet
+else
+    echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
+fi

--- a/script/uninstall
+++ b/script/uninstall
@@ -4,5 +4,5 @@ PREFIX=/usr/local
 
 echo "==> 🔥 Uninstalling mas"
 
-trash /usr/local/Frameworks/MasKit.framework
-trash /usr/local/bin/mas
+trash $PREFIX/Frameworks/MasKit.framework
+trash $PREFIX/bin/mas

--- a/script/update_headers
+++ b/script/update_headers
@@ -7,8 +7,8 @@ main() {
 }
 
 check_class_dump() {
-  which class-dump >/dev/null
-  if [ $? -ne 0 ]; then
+
+  if command --quiet --search class-dump; then
     echo "'class-dump' is not installed" >&2
     exit 1
   fi


### PR DESCRIPTION
Restored newline between each search result in `search` output. Added `SearchResultsFormatterSpec` to validate and help prevent regressions.

Also added "Actual behavior" section to issue template and removed duplicate source references from workspace.

Fixes #203