### PR TITLE
🧪📜 Update Homebrew formula, add brew_formula_update script

### DIFF
--- a/Homebrew/mas-tap.rb
+++ b/Homebrew/mas-tap.rb
@@ -2,8 +2,8 @@ class Mas < Formula
   desc "Mac App Store command-line interface"
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
-      :tag      => "v1.6.2",
-      :revision => "b3197cf3caa797aa8689cd15da3518cc7149d2ad"
+      :tag      => "v1.6.3",
+      :revision => "3ac7e51b9e9fdd33f7caf7c77bebf09bf0cce44b"
   head "https://github.com/mas-cli/mas.git"
 
   bottle do
@@ -29,7 +29,8 @@ class Mas < Formula
     EOS
     ENV["XCODE_XCCONFIG_FILE"] = xcconfig
 
-    system "carthage", "bootstrap", "--platform", "macOS"
+    # Only build necessary dependencies (Commandant, Result)
+    system "carthage", "bootstrap", "--platform", "macOS", "Commandant", "Result"
     system "script/install", prefix
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -26,7 +26,8 @@ class Mas < Formula
     EOS
     ENV["XCODE_XCCONFIG_FILE"] = xcconfig
 
-    system "carthage", "bootstrap", "--platform", "macOS"
+    # Only build necessary dependencies (Commandant, Result)
+    system "carthage", "bootstrap", "--platform", "macOS", "Commandant", "Result"
     system "script/install", prefix
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -2,14 +2,14 @@ class Mas < Formula
   desc "Mac App Store command-line interface"
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
-      :tag      => "v1.6.2",
-      :revision => "b3197cf3caa797aa8689cd15da3518cc7149d2ad"
+      :tag      => "v1.6.3",
+      :revision => "3ac7e51b9e9fdd33f7caf7c77bebf09bf0cce44b"
   head "https://github.com/mas-cli/mas.git"
 
   bottle do
     cellar :any
-    sha256 "f9909b8950efa64b86585fecc460ca280ebde507e864ba3d3f5b9e743b275a88" => :mojave
-    sha256 "9763488be11655b5b0868eff3f3f4cd91031f0da80f74bf38f292f62798cd98b" => :high_sierra
+    sha256 "3dd5a50b551a37c164c31375cc8498ba870e29e50086bd5c4c294bc26708a6d2" => :mojave
+    sha256 "a0d1e45203448c08420c3eab2d40ef957fd22c8e40fbeb067bc7bffe4f08dfe2" => :high_sierra
   end
 
   depends_on "carthage" => :build

--- a/script/brew_formula_bump
+++ b/script/brew_formula_bump
@@ -7,8 +7,7 @@
 # https://github.com/Homebrew/homebrew-core/blob/master/Formula/mas.rb
 #
 
-# BUILD_DIR="$PWD/build"
-# OS_VERSIONS=(mojave high_sierra sierra el_capitan)
+BREW_CORE_PATH="$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula"
 
 function usage {
     echo "Usage: brew_formula_bump [v1.0] [sha1_hash]"
@@ -31,6 +30,12 @@ else
     REVISION=$(git rev-parse HEAD)
 fi
 
+echo "Checking to see if this update can be a simple bump."
+if ! diff "Homebrew/mas.rb" "$BREW_CORE_PATH/mas.rb"; then
+    echo "There are changes in the local formula (Homebrew/mas.rb) that haven't been released yet."
+    exit 1
+fi
+
 echo "==> 🧪 Updating homebrew-core formula mas ($VERSION, $REVISION)"
 
 echo "Validating formula"
@@ -40,7 +45,7 @@ brew bump-formula-pr \
     --strict \
     mas
 
-pushd "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula"
+pushd "$BREW_CORE_PATH"
 
 echo "Updating formula"
 brew bump-formula-pr \
@@ -48,5 +53,4 @@ brew bump-formula-pr \
     --revision="$REVISION" \
     --strict \
     --verbose \
-    --debug \
     mas

--- a/script/brew_formula_bump
+++ b/script/brew_formula_bump
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+#
+# script/brew_formula_bump
+# mas
+#
+# Updates mas Homebrew core formula:
+# https://github.com/Homebrew/homebrew-core/blob/master/Formula/mas.rb
+#
+
+# BUILD_DIR="$PWD/build"
+# OS_VERSIONS=(mojave high_sierra sierra el_capitan)
+
+function usage {
+    echo "Usage: brew_formula_bump [v1.0] [sha1_hash]"
+    echo "- version will be inferred using version script if not provided"
+    echo "- sha will be inferred from the curreent commit if not provided"
+    exit 1
+}
+
+# arg 1 - version tag
+if test -n "$1"; then
+    VERSION="$1"
+else
+    VERSION="v$(script/version)"
+fi
+
+# arg 2 - revision (commit hash)
+if test -n "$2"; then
+    REVISION="$2"
+else
+    REVISION=$(git rev-parse HEAD)
+fi
+
+echo "==> 🧪 Updating homebrew-core formula mas ($VERSION, $REVISION)"
+
+echo "Validating formula"
+brew bump-formula-pr \
+    --tag="$VERSION" \
+    --revision="$REVISION" \
+    --strict \
+    mas
+
+pushd "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula"
+
+echo "Updating formula"
+brew bump-formula-pr \
+    --tag="$VERSION" \
+    --revision="$REVISION" \
+    --strict \
+    --verbose \
+    --debug \
+    mas

--- a/script/brew_formula_update
+++ b/script/brew_formula_update
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # script/brew_formula_update
 # mas
@@ -56,15 +56,15 @@ brew bump-formula-pr \
 # brew exit status
 status=$?
 if test $status -ne 0; then
-    echo "Formula did not validate using brew bump-formula-pr"
+    echo "Formula did not validate using 'brew bump-formula-pr'"
     exit $status
 fi
 
-pushd "$BREW_CORE_PATH"
+pushd "$BREW_CORE_PATH" || exit 2
 
 echo "Updating formula"
 if test $formula_revisions -eq 1; then
-    #
+    # Options to
     dry_run="--dry-run --write"
 fi
 
@@ -73,5 +73,5 @@ brew bump-formula-pr \
     --revision="$REVISION" \
     --strict \
     --verbose \
-    $dry_run \
+    "$dry_run" \
     mas

--- a/script/brew_formula_update
+++ b/script/brew_formula_update
@@ -6,6 +6,8 @@
 # Updates mas Homebrew core formula:
 # https://github.com/Homebrew/homebrew-core/blob/master/Formula/mas.rb
 #
+# brew bump-formula-pr --help
+#
 
 BREW_CORE_PATH="$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula"
 
@@ -31,9 +33,15 @@ else
 fi
 
 echo "Checking to see if this update can be a simple bump."
-if ! diff "Homebrew/mas.rb" "$BREW_CORE_PATH/mas.rb"; then
+diff "Homebrew/mas.rb" "$BREW_CORE_PATH/mas.rb"
+
+# diff exit status
+status=$?
+formula_revisions=0
+if test $status -ne 0; then
     echo "There are changes in the local formula (Homebrew/mas.rb) that haven't been released yet."
-    exit 1
+    #exit $status
+    formula_revisions=1
 fi
 
 echo "==> 🧪 Updating homebrew-core formula mas ($VERSION, $REVISION)"
@@ -45,12 +53,25 @@ brew bump-formula-pr \
     --strict \
     mas
 
+# brew exit status
+status=$?
+if test $status -ne 0; then
+    echo "Formula did not validate using brew bump-formula-pr"
+    exit $status
+fi
+
 pushd "$BREW_CORE_PATH"
 
 echo "Updating formula"
+if test $formula_revisions -eq 1; then
+    #
+    dry_run="--dry-run --write"
+fi
+
 brew bump-formula-pr \
     --tag="$VERSION" \
     --revision="$REVISION" \
     --strict \
     --verbose \
+    $dry_run \
     mas

--- a/script/brew_formula_update
+++ b/script/brew_formula_update
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# script/brew_formula_bump
+# script/brew_formula_update
 # mas
 #
 # Updates mas Homebrew core formula:


### PR DESCRIPTION
## 📜 `brew_formula_update`

New script wrapping the `brew bump-formula-pr` command. Hasn't been used to actually perform a release, but it looks like it can do most of the work.

1. Compares `Homebrew/mas.rb` to `$BREW_CORE_PATH/mas.rb`
  - differences will need to be manually applied
1. Run `bump-formula-pr` in validation mode
1. If there were differences between the local and core formulas:
   - bump the version in `--write` mode, allowing the user to manually apply the changes before opening a PR on homebrew-core
   - otherwise, open a PR

Note that this script hasn't been fully tested with a full formula update.