### PR TITLE
🍼 Update formula for 1.6.3

### DIFF
--- a/Homebrew/mas-tap.rb
+++ b/Homebrew/mas-tap.rb
@@ -9,10 +9,10 @@ class Mas < Formula
   bottle do
     root_url "https://dl.bintray.com/phatblat/mas-bottles"
     cellar :any
-    sha256 "451db10c91387ea9eb052b15331960508a94cc828a45e7fc62035e9793eabc04" => :mojave
-    sha256 "451db10c91387ea9eb052b15331960508a94cc828a45e7fc62035e9793eabc04" => :high_sierra
-    sha256 "451db10c91387ea9eb052b15331960508a94cc828a45e7fc62035e9793eabc04" => :sierra
-    sha256 "451db10c91387ea9eb052b15331960508a94cc828a45e7fc62035e9793eabc04" => :el_capitan
+    sha256 "2e0a42866823ef0dfd0b4e0e86f9016ab634ce7206e56c3520cb6fc18098d955" => :mojave
+    sha256 "2e0a42866823ef0dfd0b4e0e86f9016ab634ce7206e56c3520cb6fc18098d955" => :high_sierra
+    sha256 "2e0a42866823ef0dfd0b4e0e86f9016ab634ce7206e56c3520cb6fc18098d955" => :sierra
+    sha256 "2e0a42866823ef0dfd0b4e0e86f9016ab634ce7206e56c3520cb6fc18098d955" => :el_capitan
   end
 
   depends_on "carthage" => :build

--- a/script/bottle
+++ b/script/bottle
@@ -24,6 +24,16 @@ if brew ls --versions mas > /dev/null; then
     brew uninstall mas
 fi
 
+# Uninstall if still found on path
+if command -v mas > /dev/null; then
+    script/uninstall
+fi
+
+# Purge the Carthage cache to avoid this error from Homebrew sandboxing:
+# A shell task (/usr/bin/env git checkout --quiet --force 0.15.0 (launched in /Users/ben/Library/Caches/org.carthage.CarthageKit/dependencies/Commandant)) failed with exit code 128:
+# fatal: Unable to create '/Users/ben/Library/Caches/org.carthage.CarthageKit/dependencies/Commandant/./index.lock': Operation not permitted
+rm -rf ~/Library/Caches/org.carthage.CarthageKit
+
 # Build the formula
 brew install --build-bottle mas
 


### PR DESCRIPTION
Fixed the following error from the `bottle` script:

> fatal: Unable to create '/Users/ben/Library/Caches/org.carthage.CarthageKit/dependencies/Commandant/./index.lock': Operation not permitted