### PR TITLE
💡 Update readme with simpler tap usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ A simple command line interface for the Mac App Store. Designed for scripting an
 
 [Homebrew](http://brew.sh) is the preferred way to install:
 
-    brew install mas
+```bash
+brew install mas
+```
 
 ### ☎️ Older macOS Versions
 
@@ -42,73 +44,88 @@ Each application in the Mac App Store has a product identifier which is also
 used for mas-cli commands. Using `mas list` will show all installed
 applications and their product identifiers.
 
-    $ mas list
-    446107677 Screens
-    407963104 Pixelmator
-    497799835 Xcode
+```bash
+$ mas list
+446107677 Screens
+407963104 Pixelmator
+497799835 Xcode
+```
 
 It is possible to search for applications by name using `mas search` which
 will search the Mac App Store and return matching identifiers.
 Include the `--price` flag to include prices in the result.
 
-    $ mas search Xcode
-    497799835 Xcode
-    688199928 Docs for Xcode
-    449589707 Dash 3 - API Docs & Snippets. Integrates with Xcode, Alfred, TextWrangler and many more.
-    [...]
+```bash
+$ mas search Xcode
+497799835 Xcode
+688199928 Docs for Xcode
+449589707 Dash 3 - API Docs & Snippets. Integrates with Xcode, Alfred, TextWrangler and many more.
+[...]
+```
 
 To install or update an application simply run `mas install` with an
 application identifier:
 
-    $ mas install 808809998
-    ==> Downloading PaintCode 2
-    ==> Installed PaintCode 2
+```bash
+$ mas install 808809998
+==> Downloading PaintCode 2
+==> Installed PaintCode 2
+```
 
 If you want to install the first result that the `search` command returns, use the `lucky` command.
 
-     $ mas lucky twitter
-     ==> Downloading Twitter
-     ==> Installed Twitter
+```bash
+$ mas lucky twitter
+==> Downloading Twitter
+==> Installed Twitter
+```
 
 > Please note that this command will not allow you to install (or even purchase) an app for the first time:
 it must already be in the Purchased tab of the App Store.
 
 Use `mas outdated` to list all applications with pending updates.
 
-    $ mas outdated
-    497799835 Xcode (7.0)
-    446107677 Screens VNC - Access Your Computer From Anywhere (3.6.7)
+```bash
+$ mas outdated
+497799835 Xcode (7.0)
+446107677 Screens VNC - Access Your Computer From Anywhere (3.6.7)
+```
 
 > `mas` is only able to install/update applications that are listed in the Mac App Store itself.
-Use [`softwareupdate(8)`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man8/softwareupdate.8.html)
-utility for downloading system updates (like iTunes, Xcode Command Line Tools, etc)
+Use [`softwareupdate(8)`] utility for downloading system updates (like iTunes, Xcode Command Line Tools, etc)
 
 To install all pending updates run `mas upgrade`.
 
-    $ mas upgrade
-    Upgrading 2 outdated applications:
-    Xcode (7.0), Screens VNC - Access Your Computer From Anywhere (3.6.7)
-    ==> Downloading Xcode
-    ==> Installed Xcode
-    ==> Downloading iFlicks
-    ==> Installed iFlicks
+```bash
+$ mas upgrade
+Upgrading 2 outdated applications:
+Xcode (7.0), Screens VNC - Access Your Computer From Anywhere (3.6.7)
+==> Downloading Xcode
+==> Installed Xcode
+==> Downloading iFlicks
+==> Installed iFlicks
+```
 
 Updates can be performed selectively by providing the app identifier(s) to
 `mas upgrade`
 
-    $ mas upgrade 715768417
-    Upgrading 1 outdated application:
-    Xcode (8.0)
-    ==> Downloading Xcode
-    ==> Installed Xcode
+```bash
+$ mas upgrade 715768417
+Upgrading 1 outdated application:
+Xcode (8.0)
+==> Downloading Xcode
+==> Installed Xcode
+```
 
 ### 🚏📥 Sign-in
 
 To sign into the Mac App Store for the first time run `mas signin`.
 
-    $ mas signin mas@example.com
-    ==> Signing in to Apple ID: mas@example.com
-    Password:
+```bash
+$ mas signin mas@example.com
+==> Signing in to Apple ID: mas@example.com
+Password:
+```
 
 > ⚠️ Due to breaking changes in the underlying API that mas uses to interact with the Mac App Store,
 > the `signin` command has been temporarily disabled on macOS 10.13+ ⛔.
@@ -116,20 +133,24 @@ To sign into the Mac App Store for the first time run `mas signin`.
 
 If you experience issues signing in this way, you can ask to signin using a graphical dialog (provided by Mac App Store application):
 
-     $ mas signin --dialog mas@example.com
-     ==> Signing in to Apple ID: mas@example.com
+```bash
+$ mas signin --dialog mas@example.com
+==> Signing in to Apple ID: mas@example.com
+```
 
 You can also embed your password in the command.
 
-    $ mas signin mas@example.com "ZdkM4f$gzF;gX3ABXNLf8KcCt.x.np"
-    ==> Signing in to Apple ID: mas@example.com
+```bash
+$ mas signin mas@example.com 'ZdkM4f$gzF;gX3ABXNLf8KcCt.x.np'
+==> Signing in to Apple ID: mas@example.com
+```
 
 Use `mas signout` to sign out from the Mac App Store.
 
 ## 🍺 Homebrew integration
 
-`mas` is integrated with [homebrew-bundle](https://github.com/Homebrew/homebrew-bundle). If `mas` is installed, and you run `brew bundle dump`,
-then your Mac App Store apps will be included in the Brewfile created. See the [homebrew-bundle](https://github.com/Homebrew/homebrew-bundle)
+`mas` is integrated with [homebrew-bundle]. If `mas` is installed, and you run `brew bundle dump`,
+then your Mac App Store apps will be included in the Brewfile created. See the [homebrew-bundle]
 docs for more details.
 
 ## 💥 When something doesn't work
@@ -149,17 +170,17 @@ fix pasteboard behaviour which also works for `mas`.
 You should consider configuring `tmux` to use the wrapper but if you do not wish
 to do this it can be used on a one-off basis as follows:
 
-```
-$ brew install reattach-to-user-namespace
-$ reattach-to-user-namespace mas install
+```bash
+brew install reattach-to-user-namespace
+reattach-to-user-namespace mas install
 ```
 
 ## ℹ️ Build from source
 
 You can now build from Xcode by opening `mas-cli.xcodeproj`, or from the Terminal:
 
-```
-$ script/build
+```bash
+script/build
 ```
 
 Build output can be found in the `build/` directory within the project.
@@ -176,5 +197,7 @@ Tests are written using [Quick].
 mas-cli was created by [@argon](https://github.com/argon).
 Code is under the [MIT license](LICENSE).
 
+[homebrew-bundle]: https://github.com/Homebrew/homebrew-bundle
 [mas-cli]: https://github.com/mas-cli/mas
+[`softwareupdate(8)`]: https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man8/softwareupdate.8.html
 [Quick]: https://github.com/Quick/Quick

--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ for all macOS versions since 10.11.
 
 #### 😴 TL;DR
 
-Just run these commands:
+Just run this command:
 
-```
-$ brew tap mas-cli/tap
-$ brew tap-pin mas-cli/tap
-$ brew install mas
+```bash
+brew install mas-cli/tap/mas
 ```
 
 ### 🐙 GitHub Releases


### PR DESCRIPTION
`brew tap-pin` command is now deprecated.