### PR TITLE
Makefile: Add support for PREFIX in make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 
 CMD_NAME = mas
 SHELL = /bin/sh
+PREFIX ?= /usr/local
 
 # trunk
 # SWIFT_VERSION = swift-DEVELOPMENT-SNAPSHOT-2020-04-23-a
@@ -99,7 +100,7 @@ run: build
 
 .PHONY: install
 install:
-	script/install
+	script/install $(PREFIX)
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
With this patch a PREFIX can be specified using:

```bash
$ make install PREFIX=/opt/local
```