### PR TITLE
🐛 Fix alignment of 2nd column of list command output

### DIFF
--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -65,12 +65,12 @@
   "system": {
     "macos": {
       "catalina": {
-        "HOMEBREW_VERSION": "2.3.0",
+        "HOMEBREW_VERSION": "2.4.13-67-gf943af3",
         "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "c26f89c284f205e1dddca655d6620decdc72f8a9",
-        "CLT": "11.5.0.0.1.1588476445",
-        "Xcode": "11.5",
-        "macOS": "10.15.5"
+        "Homebrew/homebrew-core": "5a20f3825ca6ff1b29bcf0aad050628adcd37065",
+        "CLT": "1103.0.32.62",
+        "Xcode": "11.6",
+        "macOS": "10.15.6"
       }
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- ✨ `Makefile` #277
 - 🎨 Improve `mas list` command output #278
+- 🐛 Fix alignment of 2nd column of list command output #298
+- ✨ `Makefile` #277
 
 ## [v1.7.0] 🛍 Purchase Command - 2020-05-24
 

--- a/MasKit/Formatters/AppListFormatter.swift
+++ b/MasKit/Formatters/AppListFormatter.swift
@@ -10,21 +10,25 @@ import Foundation
 
 /// Formats text output for the search command.
 struct AppListFormatter {
+
+    static let idColumnMinWidth = 10
+    static let nameColumnMinWidth = 50
+
     /// Formats text output with list results.
     ///
     /// - Parameter products: List of sortware products app data.
     /// - Returns: Multiliune text outoutp.
     static func format(products: [SoftwareProduct]) -> String {
         // find longest appName for formatting, default 50
-        let minWidth = 50
         let maxLength = products.map { $0.appNameOrBbundleIdentifier }
             .max(by: { $1.count > $0.count })?.count
-            ?? minWidth
+            ?? nameColumnMinWidth
 
         var output: String = ""
 
         for product in products {
-            let appId = product.itemIdentifier
+            let appId = product.itemIdentifier.stringValue
+                .padding(toLength: idColumnMinWidth, withPad: " ", startingAt: 0)
             let appName = product.appNameOrBbundleIdentifier.padding(toLength: maxLength, withPad: " ", startingAt: 0)
             let version = product.bundleVersion
 

--- a/MasKitTests/Formatters/AppListFormatterSpec.swift
+++ b/MasKitTests/Formatters/AppListFormatterSpec.swift
@@ -1,0 +1,61 @@
+//
+//  AppListFormatterSpec.swift
+//  MasKitTests
+//
+//  Created by Ben Chatelain on 8/23/2020.
+//  Copyright © 2020 mas-cli. All rights reserved.
+//
+
+@testable import MasKit
+import Nimble
+import Quick
+
+class AppListsFormatterSpec: QuickSpec {
+    override func spec() {
+        // static func reference
+        let format = AppListFormatter.format(products:)
+        var products: [SoftwareProduct] = []
+
+        describe("app list formatter") {
+            beforeEach {
+                products = []
+            }
+            it("formats nothing as empty string") {
+                let output = format(products)
+                expect(output) == ""
+            }
+            it("can format a single product") {
+                products = [SoftwareProductMock(
+                    appName: "Awesome App",
+                    bundleIdentifier: "",
+                    bundlePath: "",
+                    bundleVersion: "19.2.1",
+                    itemIdentifier: 12345
+                    )]
+                let output = format(products)
+                expect(output) == "12345       Awesome App  (19.2.1)"
+            }
+            it("can format two products") {
+                products = [
+                    SoftwareProductMock(
+                        appName: "Awesome App",
+                        bundleIdentifier: "",
+                        bundlePath: "",
+                        bundleVersion: "19.2.1",
+                        itemIdentifier: 12345
+                    ),
+                    SoftwareProductMock(
+                        appName: "Even Better App",
+                        bundleIdentifier: "",
+                        bundlePath: "",
+                        bundleVersion: "1.2.0",
+                        itemIdentifier: 67890
+                    )
+                ]
+                let output = format(products)
+                expect(output) ==
+                "12345       Awesome App      (19.2.1)\n67890       Even Better App  (1.2.0)"
+            }
+        }
+    }
+}

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		F85DA8B0240C32FA00FE5650 /* SoftwareMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85DA8AF240C32FA00FE5650 /* SoftwareMap.swift */; };
 		F85DA8B2240CBAFE00FE5650 /* CKSoftwareMap+SoftwareMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85DA8B1240CBAFE00FE5650 /* CKSoftwareMap+SoftwareMap.swift */; };
 		F88CB8E12404DAAD00B691B5 /* OpenSystemCommandSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88CB8E02404DAAD00B691B5 /* OpenSystemCommandSpec.swift */; };
+		F88F258224F2FEEB00EC60D5 /* AppListFormatterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88F258124F2FEEB00EC60D5 /* AppListFormatterSpec.swift */; };
 		F8A41ECE248D76CB00D374CF /* AppListFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A41ECD248D76CB00D374CF /* AppListFormatter.swift */; };
 		F8FB715B20F2B41400F56FDC /* MasKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8FB715220F2B41400F56FDC /* MasKit.framework */; };
 		F8FB716220F2B41400F56FDC /* MasKit.h in Headers */ = {isa = PBXBuildFile; fileRef = F8FB715420F2B41400F56FDC /* MasKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -327,6 +328,7 @@
 		F85DA8AF240C32FA00FE5650 /* SoftwareMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareMap.swift; sourceTree = "<group>"; };
 		F85DA8B1240CBAFE00FE5650 /* CKSoftwareMap+SoftwareMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CKSoftwareMap+SoftwareMap.swift"; sourceTree = "<group>"; };
 		F88CB8E02404DAAD00B691B5 /* OpenSystemCommandSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSystemCommandSpec.swift; sourceTree = "<group>"; };
+		F88F258124F2FEEB00EC60D5 /* AppListFormatterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppListFormatterSpec.swift; sourceTree = "<group>"; };
 		F8A41ECD248D76CB00D374CF /* AppListFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppListFormatter.swift; sourceTree = "<group>"; };
 		F8FB715220F2B41400F56FDC /* MasKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MasKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8FB715420F2B41400F56FDC /* MasKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MasKit.h; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 		B55B3D9021ED9B6A0009A1A5 /* Formatters */ = {
 			isa = PBXGroup;
 			children = (
+				F88F258124F2FEEB00EC60D5 /* AppListFormatterSpec.swift */,
 				B55B3D9121ED9B8C0009A1A5 /* SearchResultFormatterSpec.swift */,
 			);
 			path = Formatters;
@@ -1071,6 +1074,7 @@
 				B594B12221D5416100F3AC59 /* ListCommandSpec.swift in Sources */,
 				B594B14421D6D91800F3AC59 /* LuckyCommandSpec.swift in Sources */,
 				F85DA8AE240C313900FE5650 /* MasAppLibrarySpec.swift in Sources */,
+				F88F258224F2FEEB00EC60D5 /* AppListFormatterSpec.swift in Sources */,
 				B576FDF521E1078F0016B39D /* MASErrorTestCase.swift in Sources */,
 				B576FDF321E03B780016B39D /* MasStoreSearchSpec.swift in Sources */,
 				B576FE0C21E116590016B39D /* NetworkManagerTests.swift in Sources */,


### PR DESCRIPTION
PR #87 improved the `list` command output by aligning the name and version fields vertically. However, a last-minute change to address `brew bundle` compatibility left these columns misaligned.

```
↪ mas list
549083868  Display Menu               (2.2.3)
1477385213  Save to Pocket             (1.1)
904280696  Things                     (3.12.6)
1333542190  1Password 7                (7.6)
883878097  Server                     (5.10)
```

This PR fixes the alignment as shown below.

```
↪ mas list
549083868   Display Menu               (2.2.3)
1477385213  Save to Pocket             (1.1)
904280696   Things                     (3.12.6)
1333542190  1Password 7                (7.6)
883878097   Server                     (5.10)
```