### PR TITLE
:ambulance: Changes to enable arm64 builds

### DIFF
--- a/Carthage/Checkouts/Commandant/Carthage/Checkouts/Nimble/Nimble.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Commandant/Carthage/Checkouts/Nimble/Nimble.xcodeproj/project.pbxproj
@@ -2204,7 +2204,6 @@
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -2245,7 +2244,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};

--- a/Carthage/Checkouts/Commandant/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Commandant/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/project.pbxproj
@@ -2204,7 +2204,6 @@
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -2245,7 +2244,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};

--- a/Carthage/Checkouts/Commandant/Carthage/Checkouts/Quick/Quick.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Commandant/Carthage/Checkouts/Quick/Quick.xcodeproj/project.pbxproj
@@ -2507,7 +2507,6 @@
 				PRODUCT_NAME = Quick;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -2540,7 +2539,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};

--- a/Carthage/Checkouts/Commandant/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Base.xcconfig
+++ b/Carthage/Checkouts/Commandant/Carthage/Checkouts/xcconfigs/Mac OS X/Mac-Base.xcconfig
@@ -14,6 +14,3 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_pa
 // The base SDK to use (if no version is specified, the latest version is
 // assumed)
 SDKROOT = macosx
-
-// Supported build architectures
-VALID_ARCHS = x86_64

--- a/Carthage/Checkouts/Nimble/Nimble.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Nimble/Nimble.xcodeproj/project.pbxproj
@@ -2206,7 +2206,6 @@
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -2246,7 +2245,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};
@@ -2271,7 +2269,6 @@
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -2293,7 +2290,6 @@
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};

--- a/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Quick/Externals/Nimble/Nimble.xcodeproj/project.pbxproj
@@ -2221,7 +2221,6 @@
 				PRODUCT_NAME = Nimble;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -2262,7 +2261,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};
@@ -2287,7 +2285,6 @@
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -2309,7 +2306,6 @@
 				PRODUCT_NAME = NimbleTests;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};

--- a/Carthage/Checkouts/Quick/Quick.xcodeproj/project.pbxproj
+++ b/Carthage/Checkouts/Quick/Quick.xcodeproj/project.pbxproj
@@ -2385,7 +2385,6 @@
 				PRODUCT_NAME = Quick;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -2419,7 +2418,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -1268,7 +1268,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "mas/mas-Info.plist";
 				INSTALL_PATH = /bin;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/MasKit.framework/Versions/Current/Frameworks /usr/local/Frameworks /usr/local/Frameworks/MasKit.framework/Versions/Current/Frameworks $(inherited)";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/MasKit.framework/Versions/Current/Frameworks @executable_path/../Frameworks @executable_path/../Frameworks/MasKit.framework/Versions/Current/Frameworks $(inherited)";
 				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mphys.mas-cli";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1293,7 +1293,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "mas/mas-Info.plist";
 				INSTALL_PATH = /bin;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/MasKit.framework/Versions/Current/Frameworks /usr/local/Frameworks /usr/local/Frameworks/MasKit.framework/Versions/Current/Frameworks $(inherited)";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/MasKit.framework/Versions/Current/Frameworks @executable_path/../Frameworks @executable_path/../Frameworks/MasKit.framework/Versions/Current/Frameworks $(inherited)";
 				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mphys.mas-cli";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/script/install
+++ b/script/install
@@ -27,10 +27,6 @@ INSTALL_TEMPORARY_FOLDER=${DSTROOT:-build/distributions}
 # Final destination.
 PREFIX=/usr/local
 
-# Artifacts to copy.
-FRAMEWORK_NAME=MasKit.framework
-BINARY_NAME=mas
-
 # Override default prefix path with optional 1st arg
 if test -n "$1"; then
     PREFIX="$1"
@@ -57,33 +53,3 @@ ditto -v \
     "$INSTALL_TEMPORARY_FOLDER/bin" \
     "$PREFIX/bin"
 
-# Homebrew wants to fix install linkage...
-#
-# Error: Failed changing dylib ID of /usr/local/Cellar/mas/1.4.3/Frameworks/MasKit.framework/Versions/A/Frameworks/Result.framework/Versions/A/Result
-#   from @rpath/Result.framework/Versions/A/Result
-#     to /usr/local/opt/mas/Frameworks/MasKit.framework/Versions/A/Frameworks/Result.framework/Versions/A/Result
-# Error: Failed to fix install linkage
-# The formula built, but you may encounter issues using it or linking other
-# formula against it.
-#
-# Setting the rpath to use @executable_path appears to suppress this behavior.
-
-echo "==> 🔗 Update dylib load paths"
-
-# install_name_tool
-#   -rpath old new
-#         Changes the rpath path name old to new in the specified Mach-O binary.
-#         More than one of these options can be specified. If the Mach-O binary does
-#         not contain the old rpath path name in a specified -rpath it is an error.
-
-install_name_tool \
-    -rpath \
-        "/usr/local/Frameworks" \
-        "@executable_path/../Frameworks" \
-    "$PREFIX/bin/$BINARY_NAME"
-
-install_name_tool \
-    -rpath \
-        "/usr/local/Frameworks/$FRAMEWORK_NAME/Versions/Current/Frameworks" \
-        "@executable_path/../Frameworks/$FRAMEWORK_NAME/Versions/Current/Frameworks" \
-    "$PREFIX/bin/$BINARY_NAME"


### PR DESCRIPTION
Based on @chris-araman's current pull request. I added to this the removal of all mentions of VALID_ARCH which blocks the build on arm64 architectures.