### PR TITLE
🔖 Release 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- 🎨 Improve `mas list` command output #278
-- 🐛 Fix alignment of 2nd column of list command output #298
-- ✨ `Makefile` #277
-- 🐛 Specify desired LD_RUNPATH_SEARCH_PATHS at link-time #310
+
+
+## [v1.8.0] 💪🏼 arm64 support for M1 Macs - 2021-02-12
+
+- ✨ Support for Apple Silicon (arm64) #310  
+  thanks, [@chris-araman](https://github.com/chris-araman)!
+  - ⚒️ Xcode 12.2 and macOS 10.15.4 required to build
+- 🕊 Swift 5.2 #310
+  - ⚒️ Xcode 11.4 and macOS 10.15.2 required to build
+- 🐛 Specify desired `LD_RUNPATH_SEARCH_PATHS` at link-time #310
+- 🐛 Default PREFIX to /opt/homebrew on Apple Silicon (arm64)
 - ⬆️ Commandant (0.18.0) #310
 - ⬆️ Nimble (9.0.0) #310
 - ⬆️ Quick (3.1.0) #310
-- 🕊 Swift 5.2 #310
-  - ⚒️ Xcode 11.4 and macOS 10.15.2 required to build
-- ✨ Support for Apple Silicon (arm64) #310
-  - ⚒️ Xcode 12.2 and macOS 10.15.4 required to build
-- 🐛 Default PREFIX to /opt/homebrew on Apple Silicon (arm64)
+- 🎨 Improve `mas list` command output #278  
+  thanks, [@danielbayley](https://github.com/danielbayley)!
+- 🐛 Fix alignment of 2nd column of list command output #298
+- ✨ `Makefile` #277
 
 ## [v1.7.1] 🐛 Search JSON Fix - 2020-09-06
 
@@ -218,7 +224,8 @@ Use the `mas.pkg` package to install manually.
 
 - Initial Release
 
-[Unreleased]: https://github.com/mas-cli/mas/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/mas-cli/mas/compare/v1.8.0...HEAD
+[v1.8.0]: https://github.com/mas-cli/mas/compare/v1.7.1...v1.8.0
 [v1.7.1]: https://github.com/mas-cli/mas/compare/v1.7.0...v1.7.1
 [v1.7.0]: https://github.com/mas-cli/mas/compare/v1.6.4...v1.7.0
 [v1.6.4]: https://github.com/mas-cli/mas/compare/v1.6.3...v1.6.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Carthage/Commandant" "0.18.0"
 github "Quick/Nimble" "v9.0.0"
-github "Quick/Quick" "v3.1.0"
+github "Quick/Quick" "v3.1.2"

--- a/Carthage/Checkouts/Quick/Package@swift-5.3.swift
+++ b/Carthage/Checkouts/Quick/Package@swift-5.3.swift
@@ -19,8 +19,11 @@ let package = Package(
                 name: "QuickTests",
                 dependencies: [ "Quick", "Nimble" ],
                 exclude: [
+                    "QuickAfterSuiteTests/Info.plist",
                     "QuickAfterSuiteTests/AfterSuiteTests+ObjC.m",
+                    "QuickFocusedTests/Info.plist",
                     "QuickFocusedTests/FocusedTests+ObjC.m",
+                    "QuickTests/Info.plist",
                     "QuickTests/FunctionalTests/ObjC",
                     "QuickTests/Helpers/QCKSpecRunner.h",
                     "QuickTests/Helpers/QCKSpecRunner.m",
@@ -36,11 +39,11 @@ let package = Package(
 #if os(macOS)
         targets.append(contentsOf: [
             .target(name: "QuickObjCRuntime", dependencies: []),
-            .target(name: "Quick", dependencies: [ "QuickObjCRuntime" ]),
+            .target(name: "Quick", dependencies: [ "QuickObjCRuntime" ], exclude: ["Info.plist"]),
         ])
 #else
         targets.append(contentsOf: [
-            .target(name: "Quick", dependencies: []),
+            .target(name: "Quick", dependencies: [], exclude: ["Info.plist"]),
         ])
 #endif
         return targets

--- a/Carthage/Checkouts/Quick/Quick.podspec
+++ b/Carthage/Checkouts/Quick/Quick.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Quick"
-  s.version      = "3.1.0"
+  s.version      = "3.1.2"
   s.summary      = "The Swift (and Objective-C) testing framework."
 
   s.description  = <<-DESC

--- a/Carthage/Checkouts/Quick/Sources/QuickObjCRuntime/include/QuickObjCRuntime.h
+++ b/Carthage/Checkouts/Quick/Sources/QuickObjCRuntime/include/QuickObjCRuntime.h
@@ -1,0 +1,5 @@
+#if __has_include("QuickSpecBase.h")
+#import "QuickSpecBase.h"
+#else
+#import <QuickObjCRuntime/QuickSpecBase.h>
+#endif

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (8.0.0)
+    danger (8.2.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -19,16 +19,19 @@ GEM
       faraday (>= 0.9.0, < 2.0)
       faraday-http-cache (~> 2.0)
       git (~> 1.7)
-      kramdown (~> 2.0)
+      kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    faraday (1.0.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
-    git (1.7.0)
+    faraday-net_http (1.0.1)
+    git (1.8.1)
       rchardet (~> 1.8)
     kramdown (2.3.0)
       rexml
@@ -37,14 +40,15 @@ GEM
     multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    octokit (4.18.0)
+    octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rchardet (1.8.0)
     rexml (3.2.4)
     rouge (2.0.7)
+    ruby2_keywords (0.0.4)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -62,4 +66,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.1.4
+   2.2.9

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -451,7 +451,6 @@
 		B55B3D9021ED9B6A0009A1A5 /* Formatters */ = {
 			isa = PBXGroup;
 			children = (
-				F88F258124F2FEEB00EC60D5 /* AppListFormatterSpec.swift */,
 				B55B3D9121ED9B8C0009A1A5 /* SearchResultFormatterSpec.swift */,
 			);
 			path = Formatters;
@@ -530,7 +529,6 @@
 			isa = PBXGroup;
 			children = (
 				B576FE2921E4240B0016B39D /* AppInfoFormatter.swift */,
-				F8A41ECD248D76CB00D374CF /* AppListFormatter.swift */,
 				B576FE3221E985250016B39D /* SearchResultFormatter.swift */,
 				EDCBF9541D89CFC7000039C6 /* Utilities.swift */,
 			);
@@ -1035,7 +1033,6 @@
 				B576FE0021E113610016B39D /* NetworkSession.swift in Sources */,
 				B5DBF80D21DEE4E600F3B151 /* Open.swift in Sources */,
 				B576FDF721E107AA0016B39D /* OpenSystemCommand.swift in Sources */,
-				F8A41ECE248D76CB00D374CF /* AppListFormatter.swift in Sources */,
 				F8FB717420F2B4DD00F56FDC /* Outdated.swift in Sources */,
 				75FB3E761F9F7841005B6F20 /* Purchase.swift in Sources */,
 				F8FB716C20F2B4DD00F56FDC /* PurchaseDownloadObserver.swift in Sources */,
@@ -1074,7 +1071,6 @@
 				B594B12221D5416100F3AC59 /* ListCommandSpec.swift in Sources */,
 				B594B14421D6D91800F3AC59 /* LuckyCommandSpec.swift in Sources */,
 				F85DA8AE240C313900FE5650 /* MasAppLibrarySpec.swift in Sources */,
-				F88F258224F2FEEB00EC60D5 /* AppListFormatterSpec.swift in Sources */,
 				B576FDF521E1078F0016B39D /* MASErrorTestCase.swift in Sources */,
 				B576FDF321E03B780016B39D /* MasStoreSearchSpec.swift in Sources */,
 				B576FE0C21E116590016B39D /* NetworkManagerTests.swift in Sources */,

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -1152,7 +1152,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
-				CURRENT_PROJECT_VERSION = 10700000;
+				CURRENT_PROJECT_VERSION = 10800000;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1179,7 +1179,7 @@
 					"$(SRCROOT)/App/PrivateHeaders",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mphys.mas-cli";
@@ -1220,7 +1220,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
-				CURRENT_PROJECT_VERSION = 10700000;
+				CURRENT_PROJECT_VERSION = 10800000;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1241,7 +1241,7 @@
 					"$(SRCROOT)/App/PrivateHeaders",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mphys.mas-cli";
 				SDKROOT = macosx;
@@ -1256,7 +1256,6 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 10700000;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
@@ -1265,7 +1264,6 @@
 				INFOPLIST_FILE = "mas/mas-Info.plist";
 				INSTALL_PATH = /bin;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/MasKit.framework/Versions/Current/Frameworks @executable_path/../Frameworks @executable_path/../Frameworks/MasKit.framework/Versions/Current/Frameworks $(inherited)";
-				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mphys.mas-cli";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
@@ -1280,7 +1278,6 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 10700000;
 				DEPLOYMENT_LOCATION = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1290,7 +1287,6 @@
 				INFOPLIST_FILE = "mas/mas-Info.plist";
 				INSTALL_PATH = /bin;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/MasKit.framework/Versions/Current/Frameworks @executable_path/../Frameworks @executable_path/../Frameworks/MasKit.framework/Versions/Current/Frameworks $(inherited)";
-				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mphys.mas-cli";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
@@ -1314,7 +1310,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 10700000;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 7.0;
 				DYLIB_CURRENT_VERSION = 7.0;
@@ -1327,14 +1322,12 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = MasKit/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.7.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = at.phatbl.MasKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/PrivateFrameworks/CommerceKit $(SRCROOT)/PrivateFrameworks/StoreFoundation";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
@@ -1352,7 +1345,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 10700000;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 7.0;
 				DYLIB_CURRENT_VERSION = 7.0;
@@ -1366,13 +1358,11 @@
 				INFOPLIST_FILE = MasKit/SupportingFiles/Info.plist;
 				INSTALL_PATH = /Frameworks;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.7.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = at.phatbl.MasKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/PrivateFrameworks/CommerceKit $(SRCROOT)/PrivateFrameworks/StoreFoundation";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};

--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -1401,6 +1401,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = MasKitTests/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = at.phatbl.MasKitTests;
@@ -1431,6 +1432,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = MasKitTests/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = at.phatbl.MasKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
- ✨ Support for Apple Silicon (arm64) #310  
  thanks, [@chris-araman](https://github.com/chris-araman)!
  - ⚒️ Xcode 12.2 and macOS 10.15.4 required to build
- 🕊 Swift 5.2 #310
  - ⚒️ Xcode 11.4 and macOS 10.15.2 required to build
- 🐛 Specify desired `LD_RUNPATH_SEARCH_PATHS` at link-time #310
- 🐛 Default PREFIX to /opt/homebrew on Apple Silicon (arm64)
- ⬆️ Commandant (0.18.0) #310
- ⬆️ Nimble (9.0.0) #310
- ⬆️ Quick (3.1.0) #310
- 🎨 Improve `mas list` command output #278  
  thanks, [@danielbayley](https://github.com/danielbayley)!
- 🐛 Fix alignment of 2nd column of list command output #298
- ✨ `Makefile` #277