### PR TITLE
👷🏻‍♂️ Skip hombrew in bootstrap when running on Jenkins

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -15,8 +15,11 @@ main() {
   # Install ruby tools
   bundle install
 
-  # Install Mint and shellcheck
-  brew bundle install --no-upgrade --verbose
+  # Skip Homebrew when running on Jenkins
+  if [[ $USER != "jenkins" ]]; then
+    # Install Mint and shellcheck
+    brew bundle install --no-upgrade --verbose
+  fi
 
   # Set up mint cache to be relative to user HOME
   export MINT_PATH=~/.mint/cache

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -21,11 +21,6 @@ main() {
     brew bundle install --no-upgrade --verbose
   fi
 
-  # Set up mint cache to be relative to user HOME
-  export MINT_PATH=~/.mint/cache
-  mkdir -p $MINT_PATH
-  mint bootstrap --link --verbose
-
   # Download and build project dependencies
   carthage bootstrap --platform macOS --cache-builds
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -22,7 +22,7 @@ main() {
   fi
 
   # Download and build project dependencies
-  carthage bootstrap --platform macOS --cache-builds
+  carthage bootstrap --platform macOS --cache-builds --verbose
 }
 
 main


### PR DESCRIPTION
The jenkins user doesn't have permission to install Homebrew packages.

CI fix to unblock #334 and other builds.