### PR TITLE
🪣 Use an ephemeral session

### DIFF
--- a/MasKit/Network/NetworkManager.swift
+++ b/MasKit/Network/NetworkManager.swift
@@ -19,8 +19,14 @@ public class NetworkManager {
     /// Designated initializer
     ///
     /// - Parameter session: A networking session.
-    public init(session: NetworkSession = URLSession.shared) {
+    public init(session: NetworkSession = URLSession(configuration: .ephemeral)) {
         self.session = session
+
+        // Older releases allowed URLSession to write a cache. We clean it up here.
+        do {
+            let url = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Caches/com.mphys.mas-cli")
+            try FileManager.default.removeItem(at: url)
+        } catch {}
     }
 
     /// Loads data asynchronously.


### PR DESCRIPTION
Fixes #328 and #337.

The default shared `URLSession` stores a cache in `~/Library/Caches/com.mphys.mas-cli/`. I don't think users expect `mas` to store any local state, so it should be safe to clean this up.