### PR TITLE
🤖 Configure Dependabot to update Ruby Gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆️"
+      include: "scope"


### PR DESCRIPTION
It'll create pull requests with updates saving us a little time. So far, it only supports Ruby Gem Bundler and not Homebrew (or mas!) packages, but it's a start.