### PR TITLE
🖨 Override print only in debug builds

### DIFF
--- a/Sources/MasKit/Formatters/Utilities.swift
+++ b/Sources/MasKit/Formatters/Utilities.swift
@@ -13,6 +13,8 @@ import Foundation
 /// Terminal Control Sequence Indicator
 let csi = "\u{001B}["
 
+#if DEBUG
+
 var printObserver: ((String) -> Void)?
 
 // Override global print for testability.
@@ -29,6 +31,8 @@ func print(_ items: Any..., separator: String = " ", terminator: String = "\n") 
 
     Swift.print(output)
 }
+
+#endif
 
 func printInfo(_ message: String) {
     guard isatty(fileno(stdout)) != 0 else {

--- a/Sources/MasKit/Formatters/Utilities.swift
+++ b/Sources/MasKit/Formatters/Utilities.swift
@@ -20,16 +20,22 @@ var printObserver: ((String) -> Void)?
 // Override global print for testability.
 // See MasKitTests/OutputListener.swift.
 func print(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-    let output = items
-        .map { "\($0)" }
-        .joined(separator: separator)
-        .appending(terminator)
-
     if let observer = printObserver {
+        let output = items
+            .map { "\($0)" }
+            .joined(separator: separator)
+            .appending(terminator)
         observer(output)
     }
 
-    Swift.print(output)
+    var prefix = ""
+    for item in items {
+        Swift.print(prefix, terminator: "")
+        Swift.print(item, terminator: "")
+        prefix = separator
+    }
+
+    Swift.print(terminator, terminator: "")
 }
 
 #endif


### PR DESCRIPTION
Unfortunately, the hack for `OutputListener` broke `clearLine` and color output. We don't have a way to pass the variadic arguments directly to `Swift.print` due to a [language limitation](https://bugs.swift.org/browse/SR-128).

This change fixes progress output from `mas upgrade` and color output from `printInfo`, `printWarning`, and `printError`. Additionally, we now override `print` only for debug builds.

I've verified line clearing and color output by inserting the following into `OutdatedCommand`:
```
        print("Downloading foo", terminator: "")
        clearLine()
        print("Downloading bar", terminator: "")
        clearLine()
        print("Downloading baz")
        printInfo("Complete")
```
![image](https://user-images.githubusercontent.com/283735/116921431-d3ea5e00-ac08-11eb-9768-84e32163bc99.png)