### PR TITLE
💡 Turn on the OutputListener tests

### DIFF
--- a/Tests/MasKitTests/OutputListenerSpec.swift
+++ b/Tests/MasKitTests/OutputListenerSpec.swift
@@ -9,9 +9,11 @@
 import Nimble
 import Quick
 
+@testable import MasKit
+
 class OutputListenerSpec: QuickSpec {
     override func spec() {
-        xdescribe("output listener") {
+        describe("output listener") {
             it("can intercept a single line written stdout") {
                 let output = OutputListener()
                 let expectedOutput = "hi there"


### PR DESCRIPTION
I only just realized that these haven't been running due to the existing use of `xdescribe`.