### PR TITLE
🤞🏼 Rephrase async code as PromiseKit Promises

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "PromiseKit",
+        "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
+        "state": {
+          "branch": null,
+          "revision": "aea48ea1855f5d82e2dffa6027afce3aab8f3dd7",
+          "version": "6.13.3"
+        }
+      },
+      {
         "package": "Quick",
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
         .package(url: "https://github.com/Carthage/Commandant.git", from: "0.18.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "9.1.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "4.0.0"),
+        .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.13.3"),
         .package(url: "https://github.com/mxcl/Version.git", from: "2.0.0"),
     ],
     targets: [
@@ -41,7 +42,7 @@ let package = Package(
         ),
         .target(
             name: "MasKit",
-            dependencies: ["Commandant", "Version"],
+            dependencies: ["Commandant", "PromiseKit", "Version"],
             swiftSettings: [
                 .unsafeFlags([
                     "-I", "Sources/PrivateFrameworks/CommerceKit",

--- a/Sources/MasKit/Commands/Home.swift
+++ b/Sources/MasKit/Commands/Home.swift
@@ -38,7 +38,7 @@ public struct HomeCommand: CommandProtocol {
     /// Runs the command.
     public func run(_ options: HomeOptions) -> Result<Void, MASError> {
         do {
-            guard let result = try storeSearch.lookup(app: options.appId) else {
+            guard let result = try storeSearch.lookup(app: options.appId).wait() else {
                 print("No results found")
                 return .failure(.noSearchResultsFound)
             }

--- a/Sources/MasKit/Commands/Info.swift
+++ b/Sources/MasKit/Commands/Info.swift
@@ -29,7 +29,7 @@ public struct InfoCommand: CommandProtocol {
     /// Runs the command.
     public func run(_ options: InfoOptions) -> Result<Void, MASError> {
         do {
-            guard let result = try storeSearch.lookup(app: options.appId) else {
+            guard let result = try storeSearch.lookup(app: options.appId).wait() else {
                 print("No results found")
                 return .failure(.noSearchResultsFound)
             }

--- a/Sources/MasKit/Commands/Lucky.swift
+++ b/Sources/MasKit/Commands/Lucky.swift
@@ -45,7 +45,7 @@ public struct LuckyCommand: CommandProtocol {
         var appId: Int?
 
         do {
-            let results = try storeSearch.search(for: options.appName)
+            let results = try storeSearch.search(for: options.appName).wait()
             guard let result = results.first else {
                 print("No results found")
                 return .failure(.noSearchResultsFound)

--- a/Sources/MasKit/Commands/Lucky.swift
+++ b/Sources/MasKit/Commands/Lucky.swift
@@ -73,24 +73,18 @@ public struct LuckyCommand: CommandProtocol {
     /// - Returns: Result of the operation.
     fileprivate func install(_ appId: UInt64, options: Options) -> Result<Void, MASError> {
         // Try to download applications with given identifiers and collect results
-        let downloadResults = [appId]
-            .compactMap { appId -> MASError? in
-                if let product = appLibrary.installedApp(forId: appId), !options.forceInstall {
-                    printWarning("\(product.appName) is already installed")
-                    return nil
-                }
-
-                return download(appId)
-            }
-
-        switch downloadResults.count {
-        case 0:
+        if let product = appLibrary.installedApp(forId: appId), !options.forceInstall {
+            printWarning("\(product.appName) is already installed")
             return .success(())
-        case 1:
-            return .failure(downloadResults[0])
-        default:
-            return .failure(.downloadFailed(error: nil))
         }
+
+        do {
+            try downloadAll([appId]).wait()
+        } catch {
+            return .failure(error as? MASError ?? .downloadFailed(error: error as NSError))
+        }
+
+        return .success(())
     }
 }
 

--- a/Sources/MasKit/Commands/Open.swift
+++ b/Sources/MasKit/Commands/Open.swift
@@ -54,7 +54,7 @@ public struct OpenCommand: CommandProtocol {
                 return .failure(.noSearchResultsFound)
             }
 
-            guard let result = try storeSearch.lookup(app: appId)
+            guard let result = try storeSearch.lookup(app: appId).wait()
             else {
                 print("No results found")
                 return .failure(.noSearchResultsFound)

--- a/Sources/MasKit/Commands/Search.swift
+++ b/Sources/MasKit/Commands/Search.swift
@@ -30,7 +30,7 @@ public struct SearchCommand: CommandProtocol {
 
     public func run(_ options: Options) -> Result<Void, MASError> {
         do {
-            let results = try storeSearch.search(for: options.appName)
+            let results = try storeSearch.search(for: options.appName).wait()
             if results.isEmpty {
                 print("No results found")
                 return .failure(.noSearchResultsFound)

--- a/Sources/MasKit/Commands/Upgrade.swift
+++ b/Sources/MasKit/Commands/Upgrade.swift
@@ -94,7 +94,7 @@ public struct UpgradeCommand: CommandProtocol {
         for installedApp in apps {
             // only upgrade apps whose local version differs from the store version
             group.enter()
-            storeSearch.lookup(app: installedApp.itemIdentifier.intValue) { result, _ in
+            try storeSearch.lookup(app: installedApp.itemIdentifier.intValue).done { result in
                 defer { group.leave() }
 
                 if let storeApp = result, installedApp.isOutdatedWhenComparedTo(storeApp) {
@@ -103,7 +103,7 @@ public struct UpgradeCommand: CommandProtocol {
 
                     outdated.append(installedApp)
                 }
-            }
+            }.wait()
         }
 
         group.wait()

--- a/Sources/MasKit/Commands/Upgrade.swift
+++ b/Sources/MasKit/Commands/Upgrade.swift
@@ -8,6 +8,8 @@
 
 import Commandant
 import Foundation
+import PromiseKit
+import enum Swift.Result
 
 /// Command which upgrades apps with new versions available in the Mac App Store.
 public struct UpgradeCommand: CommandProtocol {
@@ -49,27 +51,14 @@ public struct UpgradeCommand: CommandProtocol {
         print("Upgrading \(apps.count) outdated application\(apps.count > 1 ? "s" : ""):")
         print(apps.map { "\($0.appName) (\($0.bundleVersion))" }.joined(separator: ", "))
 
-        var updatedAppCount = 0
-        var failedUpgradeResults = [MASError]()
-        for app in apps {
-            if let upgradeResult = download(app.itemIdentifier.uint64Value) {
-                failedUpgradeResults.append(upgradeResult)
-            } else {
-                updatedAppCount += 1
-            }
+        let appIds = apps.map(\.itemIdentifier.uint64Value)
+        do {
+            try downloadAll(appIds).wait()
+        } catch {
+            return .failure(error as? MASError ?? .downloadFailed(error: error as NSError))
         }
 
-        switch failedUpgradeResults.count {
-        case 0:
-            if updatedAppCount == 0 {
-                print("Everything is up-to-date")
-            }
-            return .success(())
-        case 1:
-            return .failure(failedUpgradeResults[0])
-        default:
-            return .failure(.downloadFailed(error: nil))
-        }
+        return .success(())
     }
 
     private func findOutdatedApps(_ options: Options) throws -> [SoftwareProduct] {
@@ -88,27 +77,20 @@ public struct UpgradeCommand: CommandProtocol {
             }
         }
 
-        var outdated = [SoftwareProduct]()
-        let group = DispatchGroup()
-        let semaphore = DispatchSemaphore(value: 1)
-        for installedApp in apps {
+        let promises = apps.map { installedApp in
             // only upgrade apps whose local version differs from the store version
-            group.enter()
-            try storeSearch.lookup(app: installedApp.itemIdentifier.intValue).done { result in
-                defer { group.leave() }
-
-                if let storeApp = result, installedApp.isOutdatedWhenComparedTo(storeApp) {
-                    semaphore.wait()
-                    defer { semaphore.signal() }
-
-                    outdated.append(installedApp)
+            firstly {
+                storeSearch.lookup(app: installedApp.itemIdentifier.intValue)
+            }.map { result -> SoftwareProduct? in
+                guard let storeApp = result, installedApp.isOutdatedWhenComparedTo(storeApp) else {
+                    return nil
                 }
-            }.wait()
+
+                return installedApp
+            }
         }
 
-        group.wait()
-
-        return outdated
+        return try when(fulfilled: promises).wait().compactMap { $0 }
     }
 }
 

--- a/Sources/MasKit/Commands/Vendor.swift
+++ b/Sources/MasKit/Commands/Vendor.swift
@@ -38,7 +38,7 @@ public struct VendorCommand: CommandProtocol {
     /// Runs the command.
     public func run(_ options: VendorOptions) -> Result<Void, MASError> {
         do {
-            guard let result = try storeSearch.lookup(app: options.appId)
+            guard let result = try storeSearch.lookup(app: options.appId).wait()
             else {
                 print("No results found")
                 return .failure(.noSearchResultsFound)

--- a/Sources/MasKit/Controllers/MasStoreSearch.swift
+++ b/Sources/MasKit/Controllers/MasStoreSearch.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import PromiseKit
 import Version
 
 /// Manages searching the MAS catalog through the iTunes Search and Lookup APIs.
@@ -37,13 +38,12 @@ class MasStoreSearch: StoreSearch {
             return
         }
 
-        loadSearchResults(url) { results, error in
-            if let error = error {
-                completion(nil, error)
-                return
-            }
-
+        firstly {
+            loadSearchResults(url)
+        }.done { results in
             completion(results, nil)
+        }.catch { error in
+            completion(nil, error)
         }
     }
 
@@ -59,81 +59,65 @@ class MasStoreSearch: StoreSearch {
             return
         }
 
-        loadSearchResults(url) { results, error in
-            if let error = error {
-                completion(nil, error)
-                return
-            }
-
-            completion(results?.first, nil)
+        firstly {
+            loadSearchResults(url)
+        }.done { results in
+            completion(results.first, nil)
+        }.catch { error in
+            completion(nil, error)
         }
     }
 
-    private func loadSearchResults(_ url: URL, _ completion: @escaping ([SearchResult]?, Error?) -> Void) {
-        networkManager.loadData(from: url) { data, error in
-            guard let data = data else {
-                if let error = error {
-                    completion(nil, error)
-                } else {
-                    completion(nil, MASError.noData)
-                }
-
-                return
-            }
-
-            var results: SearchResultList
+    private func loadSearchResults(_ url: URL) -> Promise<[SearchResult]> {
+        firstly {
+            networkManager.loadData(from: url)
+        }.map { data -> SearchResultList in
             do {
-                results = try JSONDecoder().decode(SearchResultList.self, from: data)
+                return try JSONDecoder().decode(SearchResultList.self, from: data)
             } catch {
-                completion(nil, MASError.jsonParsing(error: error as NSError))
-                return
+                throw MASError.jsonParsing(error: error as NSError)
             }
-
-            let group = DispatchGroup()
-            for index in results.results.indices {
-                let result = results.results[index]
+        }.then { list -> Promise<[SearchResult]> in
+            var results = list.results
+            let scraping = results.indices.compactMap { index -> Guarantee<Void>? in
+                let result = results[index]
                 guard let searchVersion = Version(tolerant: result.version),
                     let pageUrl = URL(string: result.trackViewUrl)
                 else {
-                    continue
+                    return nil
                 }
 
-                group.enter()
-                self.scrapeVersionFromPage(pageUrl) { pageVersion in
+                return firstly {
+                    self.scrapeVersionFromPage(pageUrl)
+                }.done { pageVersion in
                     if let pageVersion = pageVersion, pageVersion > searchVersion {
-                        results.results[index].version = pageVersion.description
+                        results[index].version = pageVersion.description
                     }
-
-                    group.leave()
                 }
             }
 
-            group.notify(queue: DispatchQueue.global()) {
-                completion(results.results, nil)
-            }
+            return when(fulfilled: scraping).map { results }
         }
     }
 
     // The App Store often lists a newer version available in an app's page than in
     // the search results. We attempt to scrape it here.
-    private func scrapeVersionFromPage(_ pageUrl: URL, _ completion: @escaping (Version?) -> Void) {
-        networkManager.loadData(from: pageUrl) { data, _ in
-            guard let data = data else {
-                completion(nil)
-                return
-            }
-
+    private func scrapeVersionFromPage(_ pageUrl: URL) -> Guarantee<Version?> {
+        firstly {
+            networkManager.loadData(from: pageUrl)
+        }.map { data in
             let html = String(decoding: data, as: UTF8.self)
             let fullRange = NSRange(html.startIndex..<html.endIndex, in: html)
             guard let match = MasStoreSearch.versionExpression.firstMatch(in: html, range: fullRange),
                 let range = Range(match.range(at: 1), in: html),
                 let version = Version(tolerant: html[range])
             else {
-                completion(nil)
-                return
+                throw MASError.noData
             }
 
-            completion(version)
+            return version
+        }.recover { _ in
+            .value(nil)
         }
     }
 }

--- a/Sources/MasKit/Controllers/MasStoreSearch.swift
+++ b/Sources/MasKit/Controllers/MasStoreSearch.swift
@@ -31,41 +31,27 @@ class MasStoreSearch: StoreSearch {
     /// - Parameter appName: MAS ID of app
     /// - Parameter completion: A closure that receives the search results or an Error if there is a
     ///   problem with the network request. Results array will be empty if there were no matches.
-    func search(for appName: String, _ completion: @escaping ([SearchResult]?, Error?) -> Void) {
+    func search(for appName: String) -> Promise<[SearchResult]> {
         guard let url = searchURL(for: appName)
         else {
-            completion(nil, MASError.urlEncoding)
-            return
+            return Promise(error: MASError.urlEncoding)
         }
 
-        firstly {
-            loadSearchResults(url)
-        }.done { results in
-            completion(results, nil)
-        }.catch { error in
-            completion(nil, error)
-        }
+        return loadSearchResults(url)
     }
 
     /// Looks up app details.
     ///
     /// - Parameter appId: MAS ID of app
-    /// - Parameter completion: A closure that receives the search result record of app, or nil if no apps match the ID,
+    /// - Returns: A Promise for the search result record of app, or nil if no apps match the ID,
     ///   or an Error if there is a problem with the network request.
-    func lookup(app appId: Int, _ completion: @escaping (SearchResult?, Error?) -> Void) {
+    func lookup(app appId: Int) -> Promise<SearchResult?> {
         guard let url = lookupURL(forApp: appId)
         else {
-            completion(nil, MASError.urlEncoding)
-            return
+            return Promise(error: MASError.urlEncoding)
         }
 
-        firstly {
-            loadSearchResults(url)
-        }.done { results in
-            completion(results.first, nil)
-        }.catch { error in
-            completion(nil, error)
-        }
+        return loadSearchResults(url).map { results in results.first }
     }
 
     private func loadSearchResults(_ url: URL) -> Promise<[SearchResult]> {

--- a/Sources/MasKit/Controllers/StoreSearch.swift
+++ b/Sources/MasKit/Controllers/StoreSearch.swift
@@ -7,67 +7,16 @@
 //
 
 import Foundation
+import PromiseKit
 
 /// Protocol for searching the MAS catalog.
 protocol StoreSearch {
-    func lookup(app appId: Int, _ completion: @escaping (SearchResult?, Error?) -> Void)
-    func search(for appName: String, _ completion: @escaping ([SearchResult]?, Error?) -> Void)
+    func lookup(app appId: Int) -> Promise<SearchResult?>
+    func search(for appName: String) -> Promise<[SearchResult]>
 }
 
 // MARK: - Common methods
 extension StoreSearch {
-    /// Looks up app details.
-    ///
-    /// - Parameter appId: MAS ID of app
-    /// - Returns: Search result record of app or nil if no apps match the ID.
-    /// - Throws: Error if there is a problem with the network request.
-    func lookup(app appId: Int) throws -> SearchResult? {
-        var result: SearchResult?
-        var error: Error?
-
-        let group = DispatchGroup()
-        group.enter()
-        lookup(app: appId) {
-            result = $0
-            error = $1
-            group.leave()
-        }
-
-        group.wait()
-
-        if let error = error {
-            throw error
-        }
-
-        return result
-    }
-
-    /// Searches for an app.
-    ///
-    /// - Parameter appName: MAS ID of app
-    /// - Returns: Search results. Empty if there were no matches.
-    /// - Throws: Error if there is a problem with the network request.
-    func search(for appName: String) throws -> [SearchResult] {
-        var results: [SearchResult]?
-        var error: Error?
-
-        let group = DispatchGroup()
-        group.enter()
-        search(for: appName) {
-            results = $0
-            error = $1
-            group.leave()
-        }
-
-        group.wait()
-
-        if let error = error {
-            throw error
-        }
-
-        return results!
-    }
-
     /// Builds the search URL for an app.
     ///
     /// - Parameter appName: MAS app identifier.

--- a/Sources/MasKit/MasKit.swift
+++ b/Sources/MasKit/MasKit.swift
@@ -1,0 +1,27 @@
+//
+//  MasKit.swift
+//  MasKit
+//
+//  Created by Chris Araman on 4/22/21.
+//  Copyright © 2021 mas-cli. All rights reserved.
+//
+
+import PromiseKit
+
+public enum MasKit {
+    public static func initialize() {
+        PromiseKit.conf.Q.map = .global()
+        PromiseKit.conf.Q.return = .global()
+        PromiseKit.conf.logHandler = { event in
+            switch event {
+            case .waitOnMainThread:
+                // Ignored. This is a console app that waits on the main thread for
+                // promises to be processed on the global DispatchQueue.
+                break
+            default:
+                // Other events indicate a programming error.
+                fatalError("PromiseKit event: \(event)")
+            }
+        }
+    }
+}

--- a/Sources/MasKit/Network/NetworkManager.swift
+++ b/Sources/MasKit/Network/NetworkManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import PromiseKit
 
 /// Network abstraction
 class NetworkManager {
@@ -29,9 +30,9 @@ class NetworkManager {
     ///
     /// - Parameters:
     ///   - url: URL to load data from.
-    ///   - completionHandler: Closure where result is delivered.
-    func loadData(from url: URL, completionHandler: @escaping (Data?, Error?) -> Void) {
-        session.loadData(from: url, completionHandler: completionHandler)
+    /// - Returns: A Promise for the Data of the response.
+    func loadData(from url: URL) -> Promise<Data> {
+        session.loadData(from: url)
     }
 
     /// Loads data synchronously.
@@ -39,26 +40,6 @@ class NetworkManager {
     /// - Parameter url: URL to load data from.
     /// - Returns: The Data of the response.
     func loadDataSync(from url: URL) throws -> Data {
-        var data: Data?
-        var error: Error?
-        let group = DispatchGroup()
-        group.enter()
-        session.loadData(from: url) {
-            data = $0
-            error = $1
-            group.leave()
-        }
-
-        group.wait()
-
-        guard error == nil else {
-            throw error!
-        }
-
-        guard data != nil else {
-            throw MASError.noData
-        }
-
-        return data!
+        try session.loadData(from: url).wait()
     }
 }

--- a/Sources/MasKit/Network/NetworkManager.swift
+++ b/Sources/MasKit/Network/NetworkManager.swift
@@ -34,12 +34,4 @@ class NetworkManager {
     func loadData(from url: URL) -> Promise<Data> {
         session.loadData(from: url)
     }
-
-    /// Loads data synchronously.
-    ///
-    /// - Parameter url: URL to load data from.
-    /// - Returns: The Data of the response.
-    func loadDataSync(from url: URL) throws -> Data {
-        try session.loadData(from: url).wait()
-    }
 }

--- a/Sources/MasKit/Network/NetworkSession.swift
+++ b/Sources/MasKit/Network/NetworkSession.swift
@@ -7,7 +7,8 @@
 //
 
 import Foundation
+import PromiseKit
 
 protocol NetworkSession {
-    func loadData(from url: URL, completionHandler: @escaping (Data?, Error?) -> Void)
+    func loadData(from url: URL) -> Promise<Data>
 }

--- a/Sources/MasKit/Network/URLSession+NetworkSession.swift
+++ b/Sources/MasKit/Network/URLSession+NetworkSession.swift
@@ -7,12 +7,21 @@
 //
 
 import Foundation
+import PromiseKit
 
 extension URLSession: NetworkSession {
-    open func loadData(from url: URL, completionHandler: @escaping (Data?, Error?) -> Void) {
-        let task = dataTask(with: url) { data, _, error in
-            completionHandler(data, error)
+    open func loadData(from url: URL) -> Promise<Data> {
+        Promise { seal in
+            dataTask(with: url) { data, _, error in
+                if let data = data {
+                    seal.fulfill(data)
+                } else if let error = error {
+                    seal.reject(error)
+                } else {
+                    seal.reject(MASError.noData)
+                }
+            }
+            .resume()
         }
-        task.resume()
     }
 }

--- a/Sources/mas/main.swift
+++ b/Sources/mas/main.swift
@@ -10,6 +10,8 @@ import Commandant
 import Foundation
 import MasKit
 
+MasKit.initialize()
+
 struct StderrOutputStream: TextOutputStream {
     mutating func write(_ string: String) {
         fputs(string, stderr)

--- a/Tests/MasKitTests/Commands/AccountCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/AccountCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class AccountCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("Account command") {
             it("displays active account") {
                 let cmd = AccountCommand()

--- a/Tests/MasKitTests/Commands/HomeCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/HomeCommandSpec.swift
@@ -22,6 +22,9 @@ public class HomeCommandSpec: QuickSpec {
         let openCommand = OpenSystemCommandMock()
         let cmd = HomeCommand(storeSearch: storeSearch, openCommand: openCommand)
 
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("home command") {
             beforeEach {
                 storeSearch.reset()

--- a/Tests/MasKitTests/Commands/InfoCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/InfoCommandSpec.swift
@@ -36,6 +36,9 @@ public class InfoCommandSpec: QuickSpec {
 
             """
 
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("Info command") {
             beforeEach {
                 storeSearch.reset()

--- a/Tests/MasKitTests/Commands/InstallCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/InstallCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class InstallCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("install command") {
             it("installs apps") {
                 let cmd = InstallCommand()

--- a/Tests/MasKitTests/Commands/ListCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/ListCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class ListCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("list command") {
             it("lists stuff") {
                 let list = ListCommand()

--- a/Tests/MasKitTests/Commands/LuckyCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/LuckyCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class LuckyCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("lucky command") {
             it("installs the first app matching a search") {
                 let cmd = LuckyCommand()

--- a/Tests/MasKitTests/Commands/OpenCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/OpenCommandSpec.swift
@@ -23,6 +23,9 @@ public class OpenCommandSpec: QuickSpec {
         let openCommand = OpenSystemCommandMock()
         let cmd = OpenCommand(storeSearch: storeSearch, openCommand: openCommand)
 
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("open command") {
             beforeEach {
                 storeSearch.reset()

--- a/Tests/MasKitTests/Commands/OutdatedCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/OutdatedCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class OutdatedCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("outdated command") {
             it("displays apps with pending updates") {
                 let cmd = OutdatedCommand()

--- a/Tests/MasKitTests/Commands/PurchaseCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/PurchaseCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class PurchaseCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("purchase command") {
             it("purchases apps") {
                 let cmd = PurchaseCommand()

--- a/Tests/MasKitTests/Commands/ResetCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/ResetCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class ResetCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("reset command") {
             it("updates stuff") {
                 let cmd = ResetCommand()

--- a/Tests/MasKitTests/Commands/SearchCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/SearchCommandSpec.swift
@@ -21,6 +21,9 @@ public class SearchCommandSpec: QuickSpec {
         )
         let storeSearch = StoreSearchMock()
 
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("search command") {
             beforeEach {
                 storeSearch.reset()

--- a/Tests/MasKitTests/Commands/SignInCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/SignInCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class SignInCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("signn command") {
             it("updates stuff") {
                 let cmd = SignInCommand()

--- a/Tests/MasKitTests/Commands/SignOutCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/SignOutCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class SignOutCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("signout command") {
             it("updates stuff") {
                 let cmd = SignOutCommand()

--- a/Tests/MasKitTests/Commands/UninstallCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/UninstallCommandSpec.swift
@@ -14,6 +14,9 @@ import Quick
 
 public class UninstallCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("uninstall command") {
             let appId = 12345
             let app = SoftwareProductMock(

--- a/Tests/MasKitTests/Commands/UpgradeCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/UpgradeCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class UpgradeCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("upgrade command") {
             it("updates stuff") {
                 let cmd = UpgradeCommand()

--- a/Tests/MasKitTests/Commands/VendorCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/VendorCommandSpec.swift
@@ -22,6 +22,9 @@ public class VendorCommandSpec: QuickSpec {
         let openCommand = OpenSystemCommandMock()
         let cmd = VendorCommand(storeSearch: storeSearch, openCommand: openCommand)
 
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("vendor command") {
             beforeEach {
                 storeSearch.reset()

--- a/Tests/MasKitTests/Commands/VersionCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/VersionCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class VersionCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("version command") {
             it("displays the current version") {
                 let cmd = VersionCommand()

--- a/Tests/MasKitTests/Controllers/MasAppLibrarySpec.swift
+++ b/Tests/MasKitTests/Controllers/MasAppLibrarySpec.swift
@@ -15,6 +15,9 @@ public class MasAppLibrarySpec: QuickSpec {
     public override func spec() {
         let library = MasAppLibrary(softwareMap: SoftwareMapMock(products: apps))
 
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("mas app library") {
             it("contains all installed apps") {
                 expect(library.installedApps.count) == apps.count

--- a/Tests/MasKitTests/Controllers/MasStoreSearchSpec.swift
+++ b/Tests/MasKitTests/Controllers/MasStoreSearchSpec.swift
@@ -24,7 +24,7 @@ public class MasStoreSearchSpec: QuickSpec {
 
                     var results: [SearchResult]
                     do {
-                        results = try storeSearch.search(for: "slack")
+                        results = try storeSearch.search(for: "slack").wait()
                         expect(results.count) == 39
                     } catch {
                         let maserror = error as! MASError
@@ -43,7 +43,7 @@ public class MasStoreSearchSpec: QuickSpec {
 
                     var lookup: SearchResult?
                     do {
-                        lookup = try storeSearch.lookup(app: appId)
+                        lookup = try storeSearch.lookup(app: appId).wait()
                     } catch {
                         let maserror = error as! MASError
                         if case .jsonParsing(let nserror) = maserror {

--- a/Tests/MasKitTests/Controllers/MasStoreSearchSpec.swift
+++ b/Tests/MasKitTests/Controllers/MasStoreSearchSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class MasStoreSearchSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("store") {
             context("when searched") {
                 it("can find slack") {

--- a/Tests/MasKitTests/Controllers/StoreSearchMock.swift
+++ b/Tests/MasKitTests/Controllers/StoreSearchMock.swift
@@ -6,31 +6,30 @@
 //  Copyright © 2019 mas-cli. All rights reserved.
 //
 
+import PromiseKit
 @testable import MasKit
 
 class StoreSearchMock: StoreSearch {
     var apps: [Int: SearchResult] = [:]
 
-    func search(for appName: String, _ completion: @escaping ([SearchResult]?, Error?) -> Void) {
+    func search(for appName: String) -> Promise<[SearchResult]> {
         let filtered = apps.filter { $1.trackName.contains(appName) }
         let results = filtered.map { $1 }
-        completion(results, nil)
+        return .value(results)
     }
 
-    func lookup(app appId: Int, _ completion: @escaping (SearchResult?, Error?) -> Void) {
+    func lookup(app appId: Int) -> Promise<SearchResult?> {
         // Negative numbers are invalid
         guard appId > 0 else {
-            completion(nil, MASError.searchFailed)
-            return
+            return Promise(error: MASError.searchFailed)
         }
 
         guard let result = apps[appId]
         else {
-            completion(nil, MASError.noSearchResultsFound)
-            return
+            return Promise(error: MASError.noSearchResultsFound)
         }
 
-        completion(result, nil)
+        return .value(result)
     }
 
     func reset() {

--- a/Tests/MasKitTests/Controllers/StoreSearchSpec.swift
+++ b/Tests/MasKitTests/Controllers/StoreSearchSpec.swift
@@ -5,19 +5,20 @@
 //  Created by Ben Chatelain on 1/11/19.
 //  Copyright © 2019 mas-cli. All rights reserved.
 //
-import Nimble
-import Quick
 
+import Nimble
+import PromiseKit
+import Quick
 @testable import MasKit
 
 /// Protocol minimal implementation
 struct StoreSearchForTesting: StoreSearch {
-    func lookup(app _: Int, _ completion: @escaping (SearchResult?, Error?) -> Void) {
-        completion(nil, nil)
+    func lookup(app _: Int) -> Promise<SearchResult?> {
+        .value(nil)
     }
 
-    func search(for _: String, _ completion: @escaping ([SearchResult]?, Error?) -> Void) {
-        completion([], nil)
+    func search(for _: String) -> Promise<[SearchResult]> {
+        .value([])
     }
 }
 

--- a/Tests/MasKitTests/Errors/MASErrorTestCase.swift
+++ b/Tests/MasKitTests/Errors/MASErrorTestCase.swift
@@ -30,6 +30,7 @@ class MASErrorTestCase: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        MasKit.initialize()
         nserror = NSError(domain: errorDomain, code: 999)
         localizedDescription = "foo"
     }

--- a/Tests/MasKitTests/ExternalCommands/OpenSystemCommandSpec.swift
+++ b/Tests/MasKitTests/ExternalCommands/OpenSystemCommandSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class OpenSystemCommandSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("open system command") {
             context("binary path") {
                 it("defaults to the macOS open command") {

--- a/Tests/MasKitTests/Formatters/AppListFormatterSpec.swift
+++ b/Tests/MasKitTests/Formatters/AppListFormatterSpec.swift
@@ -17,6 +17,9 @@ public class AppListsFormatterSpec: QuickSpec {
         let format = AppListFormatter.format(products:)
         var products: [SoftwareProduct] = []
 
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("app list formatter") {
             beforeEach {
                 products = []

--- a/Tests/MasKitTests/Formatters/SearchResultFormatterSpec.swift
+++ b/Tests/MasKitTests/Formatters/SearchResultFormatterSpec.swift
@@ -17,6 +17,9 @@ public class SearchResultsFormatterSpec: QuickSpec {
         let format = SearchResultFormatter.format(results:includePrice:)
         var results: [SearchResult] = []
 
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("search results formatter") {
             beforeEach {
                 results = []

--- a/Tests/MasKitTests/Models/SearchResultListSpec.swift
+++ b/Tests/MasKitTests/Models/SearchResultListSpec.swift
@@ -14,6 +14,9 @@ import Quick
 
 public class SearchResultListSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("search result list") {
             it("can parse bbedit") {
                 let data = Data(from: "search/bbedit.json")

--- a/Tests/MasKitTests/Models/SearchResultSpec.swift
+++ b/Tests/MasKitTests/Models/SearchResultSpec.swift
@@ -14,6 +14,9 @@ import Quick
 
 public class SearchResultSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("search result") {
             it("can parse things") {
                 let data = Data(from: "search/things-that-go-bump.json")

--- a/Tests/MasKitTests/Network/NetworkManagerTests.swift
+++ b/Tests/MasKitTests/Network/NetworkManagerTests.swift
@@ -16,7 +16,7 @@ class NetworkManagerTests: XCTestCase {
         MasKit.initialize()
     }
 
-    func testSuccessfulAsyncResponse() {
+    func testSuccessfulAsyncResponse() throws {
         // Setup our objects
         let session = NetworkSessionMock()
         let manager = NetworkManager(session: session)
@@ -29,15 +29,8 @@ class NetworkManagerTests: XCTestCase {
         let url = URL(fileURLWithPath: "url")
 
         // Perform the request and verify the result
-        var response: Data?
-        var error: Error?
-        manager.loadData(from: url) {
-            response = $0
-            error = $1
-        }
-
+        let response = try manager.loadData(from: url).wait()
         XCTAssertEqual(response, data)
-        XCTAssertNil(error)
     }
 
     func testSuccessfulSyncResponse() throws {
@@ -68,14 +61,14 @@ class NetworkManagerTests: XCTestCase {
         let url = URL(fileURLWithPath: "url")
 
         // Perform the request and verify the result
-        var error: Error!
-        manager.loadData(from: url) { error = $1 }
-        guard let masError = error as? MASError else {
-            XCTFail("Error is of unexpected type.")
-            return
-        }
+        XCTAssertThrowsError(try manager.loadData(from: url).wait()) { error in
+            guard let masError = error as? MASError else {
+                XCTFail("Error is of unexpected type.")
+                return
+            }
 
-        XCTAssertEqual(masError, MASError.noData)
+            XCTAssertEqual(masError, MASError.noData)
+        }
     }
 
     func testFailureSyncResponse() {

--- a/Tests/MasKitTests/Network/NetworkManagerTests.swift
+++ b/Tests/MasKitTests/Network/NetworkManagerTests.swift
@@ -46,7 +46,7 @@ class NetworkManagerTests: XCTestCase {
         let url = URL(fileURLWithPath: "url")
 
         // Perform the request and verify the result
-        let result = try manager.loadDataSync(from: url)
+        let result = try manager.loadData(from: url).wait()
         XCTAssertEqual(result, data)
     }
 
@@ -82,7 +82,7 @@ class NetworkManagerTests: XCTestCase {
         let url = URL(fileURLWithPath: "url")
 
         // Perform the request and verify the result
-        XCTAssertThrowsError(try manager.loadDataSync(from: url)) { error in
+        XCTAssertThrowsError(try manager.loadData(from: url).wait()) { error in
             guard let error = error as? MASError else {
                 XCTFail("Error is of unexpected type.")
                 return

--- a/Tests/MasKitTests/Network/NetworkManagerTests.swift
+++ b/Tests/MasKitTests/Network/NetworkManagerTests.swift
@@ -11,6 +11,11 @@ import XCTest
 @testable import MasKit
 
 class NetworkManagerTests: XCTestCase {
+    public override func setUp() {
+        super.setUp()
+        MasKit.initialize()
+    }
+
     func testSuccessfulAsyncResponse() {
         // Setup our objects
         let session = NetworkSessionMock()

--- a/Tests/MasKitTests/Network/NetworkSessionMock.swift
+++ b/Tests/MasKitTests/Network/NetworkSessionMock.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-
+import PromiseKit
 @testable import MasKit
 
 /// Mock NetworkSession for testing.
@@ -22,7 +22,11 @@ class NetworkSessionMock: NetworkSession {
     /// - Parameters:
     ///   - url: unused
     ///   - completionHandler: Closure which is delivered either data or an error.
-    func loadData(from _: URL, completionHandler: @escaping (Data?, Error?) -> Void) {
-        completionHandler(data, error)
+    func loadData(from _: URL) -> Promise<Data> {
+        guard let data = data else {
+            return Promise(error: error ?? MASError.noData)
+        }
+
+        return .value(data)
     }
 }

--- a/Tests/MasKitTests/Network/NetworkSessionMockFromFile.swift
+++ b/Tests/MasKitTests/Network/NetworkSessionMockFromFile.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import PromiseKit
 
 /// Mock NetworkSession for testing with saved JSON response payload files.
 class NetworkSessionMockFromFile: NetworkSessionMock {
@@ -25,16 +26,16 @@ class NetworkSessionMockFromFile: NetworkSessionMock {
     /// - Parameters:
     ///   - url: unused
     ///   - completionHandler: Closure which is delivered either data or an error.
-    override func loadData(from _: URL, completionHandler: @escaping (Data?, Error?) -> Void) {
+    override func loadData(from _: URL) -> Promise<Data> {
         guard let fileURL = Bundle.url(for: responseFile)
         else { fatalError("Unable to load file \(responseFile)") }
 
         do {
             let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
-            completionHandler(data, nil)
+            return .value(data)
         } catch {
             print("Error opening file: \(error)")
-            completionHandler(nil, error)
+            return Promise(error: error)
         }
     }
 }

--- a/Tests/MasKitTests/OutputListener.swift
+++ b/Tests/MasKitTests/OutputListener.swift
@@ -15,7 +15,7 @@ class OutputListener {
     var contents = ""
 
     init() {
-        MasKit.printObserver = { [weak self] text in
+        printObserver = { [weak self] text in
             strongify(self) { context in
                 context.contents += text
             }
@@ -23,6 +23,6 @@ class OutputListener {
     }
 
     deinit {
-        MasKit.printObserver = nil
+        printObserver = nil
     }
 }

--- a/Tests/MasKitTests/OutputListenerSpec.swift
+++ b/Tests/MasKitTests/OutputListenerSpec.swift
@@ -13,6 +13,9 @@ import Quick
 
 public class OutputListenerSpec: QuickSpec {
     public override func spec() {
+        beforeSuite {
+            MasKit.initialize()
+        }
         describe("output listener") {
             it("can intercept a single line written stdout") {
                 let output = OutputListener()


### PR DESCRIPTION
RE: https://github.com/mas-cli/mas/pull/346#issuecomment-824562491

Using [Combine](https://developer.apple.com/documentation/combine) would seem to be the future-proof option, as that's the API Apple has produced for asynchronous programming. However, we can't use Apple's Combine yet because it requires macOS 10.15. There are some open source implementations that support older macOS releases.
🔴 [CombineX](https://github.com/cx-org/CombineX) failed `swift build`.
🟡 I made some progress with [OpenCombine](https://github.com/OpenCombine/OpenCombine), but got stuck when I found that it doesn't [yet](https://github.com/OpenCombine/OpenCombine/pull/72) implement [`merge`](https://github.com/OpenCombine/OpenCombine/issues/141).

So, here's the async code rephrased as [PromiseKit](https://github.com/mxcl/PromiseKit) promises.

👍🏼 Pros:
- 89 fewer LOC in `mas` and `MasKit`.
- Arguably improved readability.
- PromiseKit is well documented and seems to have good test coverage.

👎🏼 Cons:
- The default PromiseKit configuration assumes a UI app. `MasKit.initialize` configures PromiseKit for use in a console app, where we regularly wait on the main queue for promises to complete on the global queue. `main.swift` and all test case entry points invoke `MasKit.initialize`.
- It's another dependency to maintain.
- The `mas` executable (arm64, release) increases in size by ~388 KiB, or ~53%. I might be able to reduce this with further investigation, but considering we just shed ~13 MiB from `MasKit.framework`, I think it's probably fine.

I'm open to keeping this or dropping it. I'll leave it up to your best judgment, @phatblat.

ℹ️ Commit https://github.com/mas-cli/mas/commit/fb01f5b105a503af445202a93ff0464fd32980cc is here only to maintain existing behavior. With this commit, commands that download (or purchase) multiple apps will continue to attempt all downloads even if an earlier download fails. Without this commit, we'll stop downloading at the first failure. I'm inclined to think the behavior without this commit (failing fast) is what users would expect, but perhaps it's common for one download to fail while others succeed for reasons unrelated to [network failures](https://github.com/mas-cli/mas/issues/344). If you agree, feel free to pop that commit off the stack, or ask me to do so, before merging.