### PR TITLE
🍺 Publish bottles for custom tap to GitHub Releases

### DIFF
--- a/Homebrew/mas-tap.rb
+++ b/Homebrew/mas-tap.rb
@@ -3,19 +3,19 @@ class Mas < Formula
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
       tag:      "v1.8.2",
-      revision: "c88a98892e52a0ad8527a532aaa5dd1a2dd19635"
+      revision: "2f2a43b425498f3cee50974116b8c9d27adbb7cb"
   license "MIT"
   head "https://github.com/mas-cli/mas.git"
 
   bottle do
-    root_url "https://dl.bintray.com/phatblat/mas-bottles"
-    sha256 cellar: :any, arm64_big_sur: "d54d864976f78665d5175fd9e69ab81b3911fa28fd6ae627b61a18d55d68191a"
-    sha256 cellar: :any, big_sur:       "d54d864976f78665d5175fd9e69ab81b3911fa28fd6ae627b61a18d55d68191a"
-    sha256 cellar: :any, catalina:      "d54d864976f78665d5175fd9e69ab81b3911fa28fd6ae627b61a18d55d68191a"
-    sha256 cellar: :any, mojave:        "d54d864976f78665d5175fd9e69ab81b3911fa28fd6ae627b61a18d55d68191a"
-    sha256 cellar: :any, high_sierra:   "d54d864976f78665d5175fd9e69ab81b3911fa28fd6ae627b61a18d55d68191a"
-    sha256 cellar: :any, sierra:        "d54d864976f78665d5175fd9e69ab81b3911fa28fd6ae627b61a18d55d68191a"
-    sha256 cellar: :any, el_capitan:    "d54d864976f78665d5175fd9e69ab81b3911fa28fd6ae627b61a18d55d68191a"
+    root_url "https://github.com/mas-cli/mas/releases/download/v1.8.2"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "76d7de5e7891f049c84f079b09c25f88576d45813651bdc529a8af4660c8efa0"
+    sha256 cellar: :any_skip_relocation, big_sur:       "76d7de5e7891f049c84f079b09c25f88576d45813651bdc529a8af4660c8efa0"
+    sha256 cellar: :any_skip_relocation, catalina:      "76d7de5e7891f049c84f079b09c25f88576d45813651bdc529a8af4660c8efa0"
+    sha256 cellar: :any_skip_relocation, mojave:        "76d7de5e7891f049c84f079b09c25f88576d45813651bdc529a8af4660c8efa0"
+    sha256 cellar: :any_skip_relocation, high_sierra:   "76d7de5e7891f049c84f079b09c25f88576d45813651bdc529a8af4660c8efa0"
+    sha256 cellar: :any_skip_relocation, sierra:        "76d7de5e7891f049c84f079b09c25f88576d45813651bdc529a8af4660c8efa0"
+    sha256 cellar: :any_skip_relocation, el_capitan:    "76d7de5e7891f049c84f079b09c25f88576d45813651bdc529a8af4660c8efa0"
   end
 
   depends_on :macos

--- a/Homebrew/mas.rb
+++ b/Homebrew/mas.rb
@@ -3,14 +3,14 @@ class Mas < Formula
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
       tag:      "v1.8.2",
-      revision: "c88a98892e52a0ad8527a532aaa5dd1a2dd19635"
+      revision: "2f2a43b425498f3cee50974116b8c9d27adbb7cb"
   license "MIT"
   head "https://github.com/mas-cli/mas.git"
 
   bottle do
-    sha256 cellar: :any, arm64_big_sur: "f5ef4f44057f43ecc14f970687d832bd152bc6142c0ad848977f0a6527aa934f"
-    sha256 cellar: :any, big_sur:       "d92cfc734e730fde87b29c6bf4a50ce63a78b9e505f464dc557eee128aa06d05"
-    sha256 cellar: :any, catalina:      "163eb9cfdfed3d8fbda133b4079d104ad687f1ddb71d70d5661d02b22f562e76"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "1be3820e630aa31911100619f299b7d6b56349cc7298555ad3a7198c8846d79d"
+    sha256 cellar: :any_skip_relocation, big_sur:       "7c0d556cbae91f5770e1fb04fead95922e0931c4c897a1b940aae0347ff0e680"
+    sha256 cellar: :any_skip_relocation, catalina:      "4fe1a0f7fb506a65578b4f25cb6e9b9c40cebb13ed61941f6d41e69a04b97a7a"
   end
 
   depends_on :macos

--- a/script/bottle
+++ b/script/bottle
@@ -15,7 +15,7 @@
 BUILD_DIR="$PWD/.build"
 BOTTLE_DIR="$BUILD_DIR/bottles"
 VERSION=$(script/version)
-ROOT_URL="https://dl.bintray.com/phatblat/mas-bottles"
+ROOT_URL="https://github.com/mas-cli/mas/releases/download/v${VERSION}"
 
 # Supports macOS versions 11 (arm64 & x86_64), 10.15, 10.14, 10.13, 10.12, 10.11
 OS_NAMES=(arm64_big_sur big_sur catalina mojave high_sierra sierra el_capitan)
@@ -98,11 +98,11 @@ for os in ${OS_NAMES[*]}; do
   cp -v "${OLD_FILENAME}" "${BOTTLE_DIR}/${new_filename}"
 
   # Append each os
-  # BOTTLE_BLOCK="$(printf "${BOTTLE_BLOCK}\n  sha256 cellar: :any, %-15s %s" "${os}:" "${SHA256}")"
+  # BOTTLE_BLOCK="$(printf "${BOTTLE_BLOCK}\n  sha256 cellar: :any_skip_relocation, %-15s %s" "${os}:" "${SHA256}")"
   BOTTLE_BLOCK="$BOTTLE_BLOCK"$(
     cat <<-EOF
 
-    sha256 cellar: :any, $os: "$SHA256"
+    sha256 cellar: :any_skip_relocation, $os: "$SHA256"
 EOF
   )
 done


### PR DESCRIPTION
I figured out that Homebrew [supports](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/github_releases.rb) downloading bottles from GitHub Releases. No need to figure out how to talk to ghcr.io!

We can build `script/bottles` and upload the results from `.build/bottles` as release assets. I've already done this for [v1.8.2](https://github.com/mas-cli/mas/releases/tag/v1.8.2).

