### PR TITLE
🏡 Ignore applications moved outside the system Applications folder

### DIFF
--- a/Sources/MasKit/Controllers/MasAppLibrary.swift
+++ b/Sources/MasKit/Controllers/MasAppLibrary.swift
@@ -15,7 +15,9 @@ class MasAppLibrary: AppLibrary {
 
     /// Array of installed software products.
     lazy var installedApps: [SoftwareProduct] = {
-        softwareMap.allSoftwareProducts()
+        softwareMap.allSoftwareProducts().filter { product in
+            product.bundlePath.starts(with: "/Applications/")
+        }
     }()
 
     /// Internal initializer for providing a mock software map.


### PR DESCRIPTION
Fixes #250 and #309.

This seems like a reasonable approach, as the Mac App Store app [assumes](https://apple.stackexchange.com/a/19898) applications are always installed to `/Applications/` and not `~/Applications/` or elsewhere.

I've verified that after moving `/Applications/Microsoft PowerPoint.app` to `~/Downloads/`:
- `mas list` no longer shows PowerPoint
- `mas upgrade 462062816` yields `Warning: Nothing found to upgrade`
- `mas install 462062816` downloads it to `/Applications/` again