### PR TITLE
🧹 Lint in GitHub Actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,7 @@
 #
 # https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
 
-name: Build & Test
+name: Build, Test, and Lint
 
 on: [push]
 
@@ -11,6 +11,7 @@ jobs:
   build-test:
 
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    name: Build, Test, and Lint
     runs-on: macOS-latest
     steps:
 
@@ -31,3 +32,6 @@ jobs:
 
     - name: Test
       run: script/test
+
+    - name: Lint
+      run: script/lint

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ uninstall:
 	script/uninstall
 
 .PHONY: format
-lint:
+format:
 	script/format
 
 .PHONY: lint

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,9 +68,9 @@
         "package": "swift-format",
         "repositoryURL": "https://github.com/apple/swift-format",
         "state": {
-          "branch": null,
+          "branch": "swift-5.4-branch",
           "revision": "9c15831b798d767c9af0927a931de5d557004936",
-          "version": "0.50400.0"
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -70,12 +70,12 @@ let package = Package(
     swiftLanguageVersions: [.v5]
 )
 
-#if swift(>=5.4)
+#if compiler(>=5.4)
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-format", from: "0.50400.0")
+        .package(url: "https://github.com/apple/swift-format", .branch("swift-5.4-branch"))
     ]
-#elseif swift(>=5.3)
+#elseif compiler(>=5.3)
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-format", from: "0.50300.0")
+        .package(url: "https://github.com/apple/swift-format", .branch("swift-5.3-branch"))
     ]
 #endif

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple command line interface for the Mac App Store. Designed for scripting an
 [![Swift 5](https://img.shields.io/badge/Language-Swift_5-orange.svg)](https://swift.org)
 [![GitHub Release](https://img.shields.io/github/release/mas-cli/mas.svg)](https://github.com/mas-cli/mas/releases)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
-[![Build & Test](https://github.com/mas-cli/mas/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/mas-cli/mas/actions/workflows/build-test.yml?query=branch%3Amain)
+[![Build, Test, & Lint](https://github.com/mas-cli/mas/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/mas-cli/mas/actions/workflows/build-test.yml?query=branch%3Amain)
 
 ## 📲 Install
 

--- a/Sources/MasKit/AppStore/Downloader.swift
+++ b/Sources/MasKit/AppStore/Downloader.swift
@@ -20,11 +20,13 @@ import StoreFoundation
 func downloadAll(_ appIDs: [UInt64], purchase: Bool = false) -> Promise<Void> {
     var firstError: Error?
     return appIDs.reduce(Guarantee<Void>.value(())) { previous, appID in
-        previous.then { downloadWithRetries(appID, purchase: purchase).recover { error in
-            if firstError == nil {
-                firstError = error
+        previous.then {
+            downloadWithRetries(appID, purchase: purchase).recover { error in
+                if firstError == nil {
+                    firstError = error
+                }
             }
-        } }
+        }
     }.done {
         if let error = firstError {
             throw error
@@ -42,7 +44,8 @@ private func downloadWithRetries(
 
         // If the download failed due to network issues, try again. Otherwise, fail immediately.
         guard case MASError.downloadFailed(let downloadError) = error,
-            case NSURLErrorDomain = downloadError?.domain else {
+            case NSURLErrorDomain = downloadError?.domain
+        else {
             throw error
         }
 

--- a/Sources/MasKit/Commands/Outdated.swift
+++ b/Sources/MasKit/Commands/Outdated.swift
@@ -9,6 +9,7 @@
 import Commandant
 import Foundation
 import PromiseKit
+
 import enum Swift.Result
 
 /// Command which displays a list of installed apps which have available updates

--- a/Sources/MasKit/Commands/Upgrade.swift
+++ b/Sources/MasKit/Commands/Upgrade.swift
@@ -9,6 +9,7 @@
 import Commandant
 import Foundation
 import PromiseKit
+
 import enum Swift.Result
 
 /// Command which upgrades apps with new versions available in the Mac App Store.

--- a/Tests/MasKitTests/Commands/AccountCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/AccountCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class AccountCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/HomeCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/HomeCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class HomeCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         let result = SearchResult(
             trackId: 1111,
             trackViewUrl: "mas preview url",

--- a/Tests/MasKitTests/Commands/InfoCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/InfoCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class InfoCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         let result = SearchResult(
             currentVersionReleaseDate: "2019-01-07T18:53:13Z",
             fileSizeBytes: "1024",

--- a/Tests/MasKitTests/Commands/InstallCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/InstallCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class InstallCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/ListCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/ListCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class ListCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/LuckyCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/LuckyCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class LuckyCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/OpenCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/OpenCommandSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import MasKit
 
 public class OpenCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         let result = SearchResult(
             trackId: 1111,
             trackViewUrl: "fakescheme://some/url",

--- a/Tests/MasKitTests/Commands/OutdatedCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/OutdatedCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class OutdatedCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/PurchaseCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/PurchaseCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class PurchaseCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/ResetCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/ResetCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class ResetCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/SearchCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/SearchCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class SearchCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         let result = SearchResult(
             trackId: 1111,
             trackName: "slack",

--- a/Tests/MasKitTests/Commands/SignInCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/SignInCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class SignInCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/SignOutCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/SignOutCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class SignOutCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/UninstallCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/UninstallCommandSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import MasKit
 
 public class UninstallCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/UpgradeCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/UpgradeCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class UpgradeCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Commands/VendorCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/VendorCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class VendorCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         let result = SearchResult(
             trackId: 1111,
             trackViewUrl: "https://awesome.app",

--- a/Tests/MasKitTests/Commands/VersionCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/VersionCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class VersionCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Controllers/MasAppLibrarySpec.swift
+++ b/Tests/MasKitTests/Controllers/MasAppLibrarySpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class MasAppLibrarySpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         let library = MasAppLibrary(softwareMap: SoftwareMapMock(products: apps))
 
         beforeSuite {

--- a/Tests/MasKitTests/Controllers/MasStoreSearchSpec.swift
+++ b/Tests/MasKitTests/Controllers/MasStoreSearchSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class MasStoreSearchSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Controllers/StoreSearchMock.swift
+++ b/Tests/MasKitTests/Controllers/StoreSearchMock.swift
@@ -7,6 +7,7 @@
 //
 
 import PromiseKit
+
 @testable import MasKit
 
 class StoreSearchMock: StoreSearch {

--- a/Tests/MasKitTests/Controllers/StoreSearchSpec.swift
+++ b/Tests/MasKitTests/Controllers/StoreSearchSpec.swift
@@ -9,6 +9,7 @@
 import Nimble
 import PromiseKit
 import Quick
+
 @testable import MasKit
 
 /// Protocol minimal implementation
@@ -23,7 +24,7 @@ struct StoreSearchForTesting: StoreSearch {
 }
 
 public class StoreSearchSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         let storeSearch = StoreSearchForTesting()
 
         describe("url string") {

--- a/Tests/MasKitTests/ExternalCommands/OpenSystemCommandSpec.swift
+++ b/Tests/MasKitTests/ExternalCommands/OpenSystemCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class OpenSystemCommandSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Formatters/AppListFormatterSpec.swift
+++ b/Tests/MasKitTests/Formatters/AppListFormatterSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class AppListsFormatterSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         // static func reference
         let format = AppListFormatter.format(products:)
         var products: [SoftwareProduct] = []

--- a/Tests/MasKitTests/Formatters/SearchResultFormatterSpec.swift
+++ b/Tests/MasKitTests/Formatters/SearchResultFormatterSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class SearchResultsFormatterSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         // static func reference
         let format = SearchResultFormatter.format(results:includePrice:)
         var results: [SearchResult] = []

--- a/Tests/MasKitTests/Models/SearchResultListSpec.swift
+++ b/Tests/MasKitTests/Models/SearchResultListSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import MasKit
 
 public class SearchResultListSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Models/SearchResultSpec.swift
+++ b/Tests/MasKitTests/Models/SearchResultSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import MasKit
 
 public class SearchResultSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }

--- a/Tests/MasKitTests/Network/NetworkManagerTests.swift
+++ b/Tests/MasKitTests/Network/NetworkManagerTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import MasKit
 
 class NetworkManagerTests: XCTestCase {
-    public override func setUp() {
+    override public func setUp() {
         super.setUp()
         MasKit.initialize()
     }

--- a/Tests/MasKitTests/Network/NetworkSessionMock.swift
+++ b/Tests/MasKitTests/Network/NetworkSessionMock.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import PromiseKit
+
 @testable import MasKit
 
 /// Mock NetworkSession for testing.

--- a/Tests/MasKitTests/OutputListenerSpec.swift
+++ b/Tests/MasKitTests/OutputListenerSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import MasKit
 
 public class OutputListenerSpec: QuickSpec {
-    public override func spec() {
+    override public func spec() {
         beforeSuite {
             MasKit.initialize()
         }


### PR DESCRIPTION
This no longer runs as part of the xcodebuild. If we wanted to, we could run it from swift build by creating a Process in Package.swift.

(Creating this PR again due to stalled check in the #375 due to the rename.)