### PR TITLE
👷🏻‍♂️ Switch to self-hosted M1 Mac mini runner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+#
+# .github/CODEOWNERS
+# mas-cli/mas
+#
+
+/.github/ @mas-cli/admins

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,7 +40,7 @@ jobs:
     # https://github.com/actions/checkout#usage
     - uses: actions/checkout@v2
       with:
-        # Fetch tags for script/version
+        # A fetch-depth of 0 includes all history and tags for script/version
         fetch-depth: 0
 
     - name: Bootstrap

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,15 @@ concurrency:
 jobs:
   build-test:
 
+    # https://github.com/actions/runner/issues/805#issuecomment-942784948
+    # https://github.com/rolpdog/cffi-mirror/blob/release-1.15/.github/workflows/ci.yaml#L81-L141
+    # https://github.com/actions/virtual-environments/issues/2187#issuecomment-790507204
+    defaults:
+      run:
+        # shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
+        # run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+        shell: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     name: Build, Test, and Lint
     # https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,10 @@ jobs:
 
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     name: Build, Test, and Lint
-    runs-on: macos-latest
+    # https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow
+    # https://github.com/mas-cli/mas/settings/actions/runners
+    # runs-on: macos-latest
+    runs-on: [self-hosted, macOS]
     steps:
     # https://github.com/actions/checkout#usage
     - uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,21 +18,24 @@ concurrency:
 jobs:
   build-test:
 
-    # https://github.com/actions/runner/issues/805#issuecomment-942784948
-    # https://github.com/rolpdog/cffi-mirror/blob/release-1.15/.github/workflows/ci.yaml#L81-L141
-    # https://github.com/actions/virtual-environments/issues/2187#issuecomment-790507204
     defaults:
       run:
-        # shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
-        # run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+        # Prefixes all `run` commands with the following command to force them to run outside Rosetta.
+        # https://github.com/actions/runner/issues/805#issuecomment-942784948
+        # https://github.com/rolpdog/cffi-mirror/blob/release-1.15/.github/workflows/ci.yaml#L81-L141
+        # https://github.com/actions/virtual-environments/issues/2187#issuecomment-790507204
         shell: arch -arm64 bash --noprofile --norc -eo pipefail {0}
 
-    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     name: Build, Test, and Lint
+
+    # GitHub provided runners (in case we need to switch back)
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    # runs-on: macos-latest
+
     # https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow
     # https://github.com/mas-cli/mas/settings/actions/runners
-    # runs-on: macos-latest
     runs-on: [self-hosted, macOS]
+
     steps:
     # https://github.com/actions/checkout#usage
     - uses: actions/checkout@v2
@@ -42,7 +45,6 @@ jobs:
 
     - name: Bootstrap
       run: script/bootstrap
-      # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsenv
 
     - name: Build
       run: script/build

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -55,74 +55,74 @@
         }
       },
       "shfmt": {
-        "version": "3.4.1",
+        "version": "3.4.2",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:0de39f63c01876ea44edaf5f1db58ca6bad15ba851de3bc1065b0b71b2f9ee22",
-              "sha256": "0de39f63c01876ea44edaf5f1db58ca6bad15ba851de3bc1065b0b71b2f9ee22"
+              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:3d16adb18028a2bf572104d383a081d513ec3c608e2ea9dfd44fccf20c1e7b0f",
+              "sha256": "3d16adb18028a2bf572104d383a081d513ec3c608e2ea9dfd44fccf20c1e7b0f"
             },
             "arm64_big_sur": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:f90de59d503c1c39372f8020bdd9433a15bd543a4e27e5937f74a12972c18e92",
-              "sha256": "f90de59d503c1c39372f8020bdd9433a15bd543a4e27e5937f74a12972c18e92"
+              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:3eaff57d43b2b12b276a866e693fc76597091b6580b484cb27beb0f5b7a30f43",
+              "sha256": "3eaff57d43b2b12b276a866e693fc76597091b6580b484cb27beb0f5b7a30f43"
             },
             "monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:eae6fc1c573d7624cc282b24580272e2d77397b90340b4e5f1129d44aadcbdbd",
-              "sha256": "eae6fc1c573d7624cc282b24580272e2d77397b90340b4e5f1129d44aadcbdbd"
+              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:b4508d0a67b4a5802fa2cb9875687ec933c2369395521b23b89faf4e7eb53cad",
+              "sha256": "b4508d0a67b4a5802fa2cb9875687ec933c2369395521b23b89faf4e7eb53cad"
             },
             "big_sur": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:a7fb4f0b937883ff6367db892986823efc894d67ea77514fd88a8d49d95c87d1",
-              "sha256": "a7fb4f0b937883ff6367db892986823efc894d67ea77514fd88a8d49d95c87d1"
+              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:b6765390c7387bb16bfa4fb63bb75bedf346bd2f42e70b2042c88230e668bd70",
+              "sha256": "b6765390c7387bb16bfa4fb63bb75bedf346bd2f42e70b2042c88230e668bd70"
             },
             "catalina": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:41d8f6bf716a000fa3c5f36720d4c22e23951cba71b619716fe5e792eee7ab38",
-              "sha256": "41d8f6bf716a000fa3c5f36720d4c22e23951cba71b619716fe5e792eee7ab38"
+              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:ab7bb4cf991a41eecda3fca4bef473dd711a62b89d906f3861515b8ec1386c98",
+              "sha256": "ab7bb4cf991a41eecda3fca4bef473dd711a62b89d906f3861515b8ec1386c98"
             },
             "x86_64_linux": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:c13c9a6d768d8fda58e741ff1148baa2d5ca1d9ae9d96bb2441a818f045285b8",
-              "sha256": "c13c9a6d768d8fda58e741ff1148baa2d5ca1d9ae9d96bb2441a818f045285b8"
+              "url": "https://ghcr.io/v2/homebrew/core/shfmt/blobs/sha256:8ed1ad0c691990dd7bc6bc1665f5c47f6815b73ad28e7d97bce07af69b28f962",
+              "sha256": "8ed1ad0c691990dd7bc6bc1665f5c47f6815b73ad28e7d97bce07af69b28f962"
             }
           }
         }
       },
       "swiftformat": {
-        "version": "0.49.0",
+        "version": "0.49.1",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:7c9e0d59c03ef20c160a3218dd0538f1629a6e417ff006926a981822e7127ebc",
-              "sha256": "7c9e0d59c03ef20c160a3218dd0538f1629a6e417ff006926a981822e7127ebc"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:c43caffb4d2cf9546b0a8fa732ffe5d95b1b1fd7ab03f1c5da39c8e7a0e8ecb4",
+              "sha256": "c43caffb4d2cf9546b0a8fa732ffe5d95b1b1fd7ab03f1c5da39c8e7a0e8ecb4"
             },
             "arm64_big_sur": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:344924164e034a532cc57a1bb0a0e6751f8ef9157671e32cfb96a39c5b121d39",
-              "sha256": "344924164e034a532cc57a1bb0a0e6751f8ef9157671e32cfb96a39c5b121d39"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:ad0ce5fc15fe1d339d366ece18694fdc1d14021684462a126ed20b537a1a9bf5",
+              "sha256": "ad0ce5fc15fe1d339d366ece18694fdc1d14021684462a126ed20b537a1a9bf5"
             },
             "monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:9313dc428fd0ee222b0850c57a5449a2b2c2b59f01ff90b0f4edfa572f357dc2",
-              "sha256": "9313dc428fd0ee222b0850c57a5449a2b2c2b59f01ff90b0f4edfa572f357dc2"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:33652b8015d31dbe45e00bdc598f1b228cb63c7083b90137fdec66318a88010f",
+              "sha256": "33652b8015d31dbe45e00bdc598f1b228cb63c7083b90137fdec66318a88010f"
             },
             "big_sur": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:cff603ec304a16944d56ce4fc6a56c7e67c1395fba33476f84d68e4bbfd15ffa",
-              "sha256": "cff603ec304a16944d56ce4fc6a56c7e67c1395fba33476f84d68e4bbfd15ffa"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:f0ad88e5594a6a3e5a35834a9a22473a05511375942dbb046d1085cc537d60b8",
+              "sha256": "f0ad88e5594a6a3e5a35834a9a22473a05511375942dbb046d1085cc537d60b8"
             },
             "catalina": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:b8231ff96ed53eab67dd0b0adad04ac4ff7d6f72e08952d0f81fdc8db2171224",
-              "sha256": "b8231ff96ed53eab67dd0b0adad04ac4ff7d6f72e08952d0f81fdc8db2171224"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftformat/blobs/sha256:564f5daf9cd82407843aed590bd4190f3e5aaa73a30b3bc8ae07135f1319ac97",
+              "sha256": "564f5daf9cd82407843aed590bd4190f3e5aaa73a30b3bc8ae07135f1319ac97"
             }
           }
         }
@@ -145,12 +145,12 @@
   "system": {
     "macos": {
       "monterey": {
-        "HOMEBREW_VERSION": "3.3.6-72-g5096d6e",
+        "HOMEBREW_VERSION": "3.3.9-36-ge970bb1",
         "HOMEBREW_PREFIX": "/opt/homebrew",
-        "Homebrew/homebrew-core": "e31f0421699fa73de6e02b4afcc4c708d687d9fd",
-        "CLT": "13.1.0.0.1.1633545042",
-        "Xcode": "13.1",
-        "macOS": "12.0.1"
+        "Homebrew/homebrew-core": "f2b69fcaf6cf9925caac56dad26d39d30e89b42c",
+        "CLT": "13.2.0.0.1.1638488800",
+        "Xcode": "13.2.1",
+        "macOS": "12.1"
       }
     }
   }

--- a/script/test
+++ b/script/test
@@ -7,4 +7,4 @@
 #
 
 echo "==> ✅ Testing"
-swift test 2>&1
+swift test

--- a/script/test
+++ b/script/test
@@ -7,5 +7,4 @@
 #
 
 echo "==> ✅ Testing"
-swift test
-
+swift test 2>&1

--- a/script/test
+++ b/script/test
@@ -8,3 +8,4 @@
 
 echo "==> ✅ Testing"
 swift test
+


### PR DESCRIPTION
GitHub Actions only support "X64" architecture right now, so the [current solution](https://gregmfoster.medium.com/using-m1-mac-minis-to-power-our-github-actions-ios-ci-540c55af13ea) relies on Rosetta 2. Xcode builds (at least running XCUITests) require `arch -arm64` prefixed to the commands, but it seems that Swift build & test do not.

Fixes #380 

Scripts in https://github.com/mas-cli/m1-github-actions-runner

```
↪ ./start.sh

--------------------------------------------------------------------------------
|        ____ _ _   _   _       _          _        _   _                      |
|       / ___(_) |_| | | |_   _| |__      / \   ___| |_(_) ___  _ __  ___      |
|      | |  _| | __| |_| | | | | '_ \    / _ \ / __| __| |/ _ \| '_ \/ __|     |
|      | |_| | | |_|  _  | |_| | |_) |  / ___ \ (__| |_| | (_) | | | \__ \     |
|       \____|_|\__|_| |_|\__,_|_.__/  /_/   \_\___|\__|_|\___/|_| |_|___/     |
|                                                                              |
|                       Self-hosted runner registration                        |
|                                                                              |
--------------------------------------------------------------------------------

# Authentication

What is the URL of your repository? https://github.com/mas-cli/mas
What is your runner register token? *****************************

√ Connected to GitHub

# Runner Registration

Enter the name of runner: [press Enter for m1]

This runner will have the following labels: 'self-hosted', 'macOS', 'X64'
Enter any additional labels (ex. label-1,label-2): [press Enter to skip]

√ Runner successfully added
√ Runner connection is good

# Runner settings

Enter name of work folder: [press Enter for _work]

√ Settings Saved.


√ Connected to GitHub

2021-05-13 05:48:05Z: Listening for Jobs
2021-05-13 06:03:27Z: Running job: Build, Test, and Lint
2021-05-13 06:07:10Z: Job Build, Test, and Lint completed with result: Succeeded
```

## TODO

- [x] Get runner app working with scripts run outside Rosetta
- [x] Configure code owners for `.github` files
- [x] Clean up experiments
- [x] Set the runner app to auto-launch on startup 
- [x] Move mini back into DMZ vlan