### PR TITLE
⬆️ PromiseKit (6.16.0)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
         "state": {
           "branch": null,
-          "revision": "d2f7ba14bcdc45e18f4f60ad9df883fb9055f081",
-          "version": "6.15.3"
+          "revision": "2ff97931d2721ecae9f94d8cbf4cf853a7d79180",
+          "version": "6.16.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/Carthage/Commandant.git", from: "0.18.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "9.2.1"),
         .package(url: "https://github.com/Quick/Quick.git", from: "4.0.0"),
-        .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.15.3"),
+        .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.16.0"),
         .package(url: "https://github.com/mxcl/Version.git", from: "2.0.1"),
     ],
     targets: [


### PR DESCRIPTION
Just keeping up rather than catching up. The `pk7` branch still has the PromiseKit 7 WIP. Swift 5.5 async/await still requires macOS 12.