### PR TITLE
🐛 Fix link to known issues

### DIFF
--- a/Sources/MasKit/Errors/MASError.swift
+++ b/Sources/MasKit/Errors/MASError.swift
@@ -43,7 +43,7 @@ extension MASError: CustomStringConvertible {
             return """
                 This command is not supported on this macOS version due to changes in macOS. \
                 For more information see: \
-                https://github.com/mas-cli/mas#known-issues
+                https://github.com/mas-cli/mas#%EF%B8%8F-known-issues
                 """
 
         case .signInFailed(let error):


### PR DESCRIPTION
The corresponding section header starts with "⚠️", which needs to be
encoded in the link. Otherwise, the anchor doesn't work.