### PR TITLE
📜 Script fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,11 @@ bottles:
 bottle: bottles
 
 .PHONY: package
-package:
+package: build
 	script/package
 
 .PHONY: packageInstall
-packageInstall:
+packageInstall: package
 	script/package_install
 
 .PHONY: describe

--- a/script/install
+++ b/script/install
@@ -23,7 +23,7 @@ fi
 while test -n "$1"; do
   if [[ "$1" == '--universal' ]]; then
     ARCH=universal
-    RELEASE=.build/apple/Products/Release
+    RELEASE=.build/release
   else
     # Override default prefix path with optional arg
     PREFIX="$1"


### PR DESCRIPTION
While generating the `.pkg` for #450 it appears that current versions of Swift output binaries to a different subfolder under `.build/`. Also added dependencies to a couple of make targets to ensure things are run in the correct order.