### PR TITLE
🔇 Error message cleanup

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "04d4497be6b88e524a71778d828790e9589ae1c4",
-          "version": "0.50700.0"
+          "revision": "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+          "version": "0.50700.1"
         }
       },
       {

--- a/Sources/MasKit/Commands/Account.swift
+++ b/Sources/MasKit/Commands/Account.swift
@@ -27,7 +27,7 @@ public struct AccountCommand: CommandProtocol {
         if let account = ISStoreAccount.primaryAccount {
             print(String(describing: account.identifier))
         } else {
-            print("Not signed in")
+            printError("Not signed in")
             return .failure(.notSignedIn)
         }
         return .success(())

--- a/Sources/MasKit/Commands/Home.swift
+++ b/Sources/MasKit/Commands/Home.swift
@@ -39,7 +39,6 @@ public struct HomeCommand: CommandProtocol {
     public func run(_ options: HomeOptions) -> Result<Void, MASError> {
         do {
             guard let result = try storeSearch.lookup(app: options.appId).wait() else {
-                print("No results found")
                 return .failure(.noSearchResultsFound)
             }
 

--- a/Sources/MasKit/Commands/Info.swift
+++ b/Sources/MasKit/Commands/Info.swift
@@ -30,7 +30,6 @@ public struct InfoCommand: CommandProtocol {
     public func run(_ options: InfoOptions) -> Result<Void, MASError> {
         do {
             guard let result = try storeSearch.lookup(app: options.appId).wait() else {
-                print("No results found")
                 return .failure(.noSearchResultsFound)
             }
 

--- a/Sources/MasKit/Commands/List.swift
+++ b/Sources/MasKit/Commands/List.swift
@@ -32,7 +32,7 @@ public struct ListCommand: CommandProtocol {
     public func run(_: Options) -> Result<Void, MASError> {
         let products = appLibrary.installedApps
         if products.isEmpty {
-            print("No installed apps found")
+            printError("No installed apps found")
             return .success(())
         }
 

--- a/Sources/MasKit/Commands/Lucky.swift
+++ b/Sources/MasKit/Commands/Lucky.swift
@@ -47,7 +47,7 @@ public struct LuckyCommand: CommandProtocol {
         do {
             let results = try storeSearch.search(for: options.appName).wait()
             guard let result = results.first else {
-                print("No results found")
+                printError("No results found")
                 return .failure(.noSearchResultsFound)
             }
 

--- a/Sources/MasKit/Commands/Open.swift
+++ b/Sources/MasKit/Commands/Open.swift
@@ -56,7 +56,6 @@ public struct OpenCommand: CommandProtocol {
 
             guard let result = try storeSearch.lookup(app: appId).wait()
             else {
-                print("No results found")
                 return .failure(.noSearchResultsFound)
             }
 

--- a/Sources/MasKit/Commands/Outdated.swift
+++ b/Sources/MasKit/Commands/Outdated.swift
@@ -73,7 +73,6 @@ public struct OutdatedCommand: CommandProtocol {
     }
 }
 
-
 public struct OutdatedOptions: OptionsProtocol {
     public typealias ClientError = MASError
 

--- a/Sources/MasKit/Commands/Outdated.swift
+++ b/Sources/MasKit/Commands/Outdated.swift
@@ -15,7 +15,7 @@ import enum Swift.Result
 /// Command which displays a list of installed apps which have available updates
 /// ready to be installed from the Mac App Store.
 public struct OutdatedCommand: CommandProtocol {
-    public typealias Options = NoOptions<MASError>
+    public typealias Options = OutdatedOptions
     public let verb = "outdated"
     public let function = "Lists pending updates from the Mac App Store"
 
@@ -36,17 +36,19 @@ public struct OutdatedCommand: CommandProtocol {
     }
 
     /// Runs the command.
-    public func run(_: Options) -> Result<Void, MASError> {
+    public func run(_ options: Options) -> Result<Void, MASError> {
         let promises = appLibrary.installedApps.map { installedApp in
             firstly {
                 storeSearch.lookup(app: installedApp.itemIdentifier.intValue)
             }.done { storeApp in
                 guard let storeApp = storeApp else {
-                    printWarning(
-                        """
-                        Identifier \(installedApp.itemIdentifier) not found in store. \
-                        Was expected to identify \(installedApp.appName).
-                        """)
+                    if options.verbose {
+                        printWarning(
+                            """
+                            Identifier \(installedApp.itemIdentifier) not found in store. \
+                            Was expected to identify \(installedApp.appName).
+                            """)
+                    }
                     return
                 }
 
@@ -68,5 +70,21 @@ public struct OutdatedCommand: CommandProtocol {
             // Bubble up MASErrors
             .value(Result<Void, MASError>.failure(error as? MASError ?? .searchFailed))
         }.wait()
+    }
+}
+
+
+public struct OutdatedOptions: OptionsProtocol {
+    public typealias ClientError = MASError
+
+    let verbose: Bool
+
+    static func create(verbose: Bool) -> OutdatedOptions {
+        OutdatedOptions(verbose: verbose)
+    }
+
+    public static func evaluate(_ mode: CommandMode) -> Result<OutdatedOptions, CommandantError<MASError>> {
+        create
+        <*> mode <| Switch(flag: nil, key: "verbose", usage: "Show warnings about apps")
     }
 }

--- a/Sources/MasKit/Commands/Search.swift
+++ b/Sources/MasKit/Commands/Search.swift
@@ -32,7 +32,6 @@ public struct SearchCommand: CommandProtocol {
         do {
             let results = try storeSearch.search(for: options.appName).wait()
             if results.isEmpty {
-                print("No results found")
                 return .failure(.noSearchResultsFound)
             }
 

--- a/Sources/MasKit/Commands/Vendor.swift
+++ b/Sources/MasKit/Commands/Vendor.swift
@@ -40,7 +40,6 @@ public struct VendorCommand: CommandProtocol {
         do {
             guard let result = try storeSearch.lookup(app: options.appId).wait()
             else {
-                print("No results found")
                 return .failure(.noSearchResultsFound)
             }
 

--- a/Sources/MasKit/Formatters/Utilities.swift
+++ b/Sources/MasKit/Formatters/Utilities.swift
@@ -79,6 +79,7 @@ extension FileHandle: TextOutputStream {
     }
 }
 
+/// Prints a message to stdout prefixed with a blue arrow.
 func printInfo(_ message: String) {
     guard isatty(fileno(stdout)) != 0 else {
         print("==> \(message)")
@@ -89,6 +90,7 @@ func printInfo(_ message: String) {
     print("\(csi)1;34m==>\(csi)0m \(csi)1m\(message)\(csi)0m")
 }
 
+/// Prints a message to stderr prefixed with "Warning:" underlined in yellow.
 public func printWarning(_ message: String) {
     guard isatty(fileno(stderr)) != 0 else {
         print("Warning: \(message)", to: &standardError)
@@ -99,6 +101,7 @@ public func printWarning(_ message: String) {
     print("\(csi)4;33mWarning:\(csi)0m \(message)", to: &standardError)
 }
 
+/// Prints a message to stderr prefixed with "Error:" underlined in red.
 public func printError(_ message: String) {
     guard isatty(fileno(stderr)) != 0 else {
         print("Error: \(message)", to: &standardError)
@@ -109,6 +112,7 @@ public func printError(_ message: String) {
     print("\(csi)4;31mError:\(csi)0m \(message)", to: &standardError)
 }
 
+/// Flushes stdout.
 func clearLine() {
     guard isatty(fileno(stdout)) != 0 else {
         return

--- a/Tests/MasKitTests/Commands/OutdatedCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/OutdatedCommandSpec.swift
@@ -19,9 +19,9 @@ public class OutdatedCommandSpec: QuickSpec {
         describe("outdated command") {
             it("displays apps with pending updates") {
                 let cmd = OutdatedCommand()
-                let result = cmd.run(OutdatedCommand.Options())
+                let result = cmd.run(OutdatedCommand.Options(verbose: true))
                 print(result)
-                //                expect(result).to(beSuccess())
+                expect(result).to(beSuccess())
             }
         }
     }


### PR DESCRIPTION
Cleanup of error messages.

- Removed some duplicate error messages
- All errors printed to `stderr` now
- Added `--verbose` flag to `outdated` command. Warnings about apps removed from the App Store will only be shown when flag provided.

```
❯ mas outdated
803453959 Slack (4.28.182 -> 4.28.184)
1055511498 Day One (7.16 -> 7.17)

❯ mas outdated --verbose
Warning: Identifier 883878097 not found in store. Was expected to identify Server.
Warning: Identifier 1125131804 not found in store. Was expected to identify Later.
Warning: Identifier 588726889 not found in store. Was expected to identify ReadKit.
Warning: Identifier 980258689 not found in store. Was expected to identify SSDReporter.
Warning: Identifier 927292435 not found in store. Was expected to identify iStat Mini.
Warning: Identifier 1381523962 not found in store. Was expected to identify Houseparty.
Warning: Identifier 1475897096 not found in store. Was expected to identify Jira.
Warning: Identifier 781577745 not found in store. Was expected to identify Dumper.
Warning: Identifier 924726344 not found in store. Was expected to identify Deliveries.
803453959 Slack (4.28.182 -> 4.28.184)
1055511498 Day One (7.16 -> 7.17)
```