### PR TITLE
fix int format in search results

### DIFF
--- a/Sources/MasKit/Formatters/SearchResultFormatter.swift
+++ b/Sources/MasKit/Formatters/SearchResultFormatter.swift
@@ -26,9 +26,9 @@ enum SearchResultFormatter {
             let price = result.price ?? 0.0
 
             if includePrice {
-                output += String(format: "%12d  %@  $%5.2f  (%@)\n", appId, appName, price, version)
+                output += String(format: "%12ld  %@  $%5.2f  (%@)\n", appId, appName, price, version)
             } else {
-                output += String(format: "%12d  %@ (%@)\n", appId, appName, version)
+                output += String(format: "%12ld  %@ (%@)\n", appId, appName, version)
             }
         }
 


### PR DESCRIPTION
Since `trackId` is an `Int` and can be a number greater than `Int32.max`, it should be printed with the `%ld` [format specifier](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html#//apple_ref/doc/uid/TP40004265-SW5).

Fixes https://github.com/mas-cli/mas/issues/478