### PR TITLE
Reenable `purchase`

### DIFF
--- a/Sources/MasKit/Commands/Purchase.swift
+++ b/Sources/MasKit/Commands/Purchase.swift
@@ -32,7 +32,8 @@ public struct PurchaseCommand: CommandProtocol {
         if #available(macOS 10.15, *) {
             // Purchases are no longer possible as of Catalina.
             // https://github.com/mas-cli/mas/issues/289
-            return .failure(.notSupported)
+	    printWarning("Purchases are no longer supported as of Catalina. (but may work)")
+	    // return .failure(.notSupported)
         }
 
         // Try to download applications with given identifiers and collect results


### PR DESCRIPTION
I tried `mas purchase` on my Ventura 13.3.1 M1 MBA and it worked perfectly. I don't know from which version it started working so I propose instead of failing just warn the user. At least until we know from which version it started working again then it can be reverted to failing but only within a certain version range. 

Please feel free to edit this PR to make it suitable I just did this so I can install free apps I haven't purchased.