### PR TITLE
🔧 Check for mac updates only

### DIFF
--- a/Sources/MasKit/Controllers/StoreSearch.swift
+++ b/Sources/MasKit/Controllers/StoreSearch.swift
@@ -48,7 +48,10 @@ extension StoreSearch {
             return nil
         }
 
-        components.queryItems = [URLQueryItem(name: "id", value: "\(appId)")]
+        components.queryItems = [
+            URLQueryItem(name: "id", value: "\(appId)"),
+            URLQueryItem(name: "entity", value: "desktopSoftware"),
+        ]
 
         if let country = country {
             components.queryItems!.append(country)


### PR DESCRIPTION
Attempt to fix #491, #336 (and some other dup issue)

This idea is from [https://github.com/mangerlahn/Latest](https://github.com/mangerlahn/Latest/blob/9e98e7317926597d98d323c43a562d6caeca21c7/Latest/Model/Update%20Checker%20Extensions/MacAppStoreCheckerOperation.swift#L114-L127)(Thanks!). They also added "macSoftware" param, which I believe is unnecessary for us as it is not possible to upgrade an iOS-only app from command-line. (Not 100% sure, if that causes problem, we can add the param in the future)