### PR TITLE
Resolve Issues #491 and #336 regarding upgrade functionality

### DIFF
--- a/Sources/MasKit/Controllers/StoreSearch.swift
+++ b/Sources/MasKit/Controllers/StoreSearch.swift
@@ -48,7 +48,10 @@ extension StoreSearch {
             return nil
         }
 
-        components.queryItems = [URLQueryItem(name: "id", value: "\(appId)")]
+        components.queryItems = [
+            URLQueryItem(name: "id", value: "\(appId)"),
+            URLQueryItem(name: "entity", value: "desktopSoftware"),
+        ]
 
         if let country = country {
             components.queryItems!.append(country)


### PR DESCRIPTION
Description:
This PR aims to address the upgrade issues documented in #491 and #336 on the mas-cli main branch. The solution has been derived from the discussion and proposed changes in Pull Request #496. 
The following change has been made in `Sources/Maskit/Controllers/StoreSearch.swift`:

```diff
51c51,53
<        components.queryItems = [URLQueryItem(name: "id", value: "\(appId)")]
---
>        components.queryItems = [
>            URLQueryItem(name: "id", value: "\(appId)"),
>            URLQueryItem(name: "entity", value: "desktopSoftware"),
>        ]

This correction enhances the upgrade functionality, aligning it with the expected behavior as discussed in the aforementioned issues and PR.

I have tested these changes on macOS Ventura 13.6, and confirmed the upgrade functionality now works as expected.
