### PR TITLE
Output to stderr responses from Apple endpoints that are unparsable as JSON

### DIFF
--- a/Sources/MasKit/Controllers/MasStoreSearch.swift
+++ b/Sources/MasKit/Controllers/MasStoreSearch.swift
@@ -108,7 +108,7 @@ class MasStoreSearch: StoreSearch {
             do {
                 return try JSONDecoder().decode(SearchResultList.self, from: data).results
             } catch {
-                throw MASError.jsonParsing(error: error as NSError)
+                throw MASError.jsonParsing(data: data)
             }
         }
     }
@@ -122,8 +122,9 @@ class MasStoreSearch: StoreSearch {
         firstly {
             networkManager.loadData(from: pageUrl)
         }.map { data in
-            let html = String(decoding: data, as: UTF8.self)
-            guard let capture = MasStoreSearch.appVersionExpression.firstMatch(in: html)?.captures[0],
+            let html = String(data: data, encoding: .utf8)
+            guard let html,
+                let capture = MasStoreSearch.appVersionExpression.firstMatch(in: html)?.captures[0],
                 let version = Version(tolerant: capture)
             else {
                 return nil

--- a/Sources/MasKit/Errors/MASError.swift
+++ b/Sources/MasKit/Errors/MASError.swift
@@ -28,7 +28,7 @@ public enum MASError: Error, Equatable {
     case uninstallFailed
 
     case noData
-    case jsonParsing(error: NSError?)
+    case jsonParsing(data: Data?)
 }
 
 // MARK: - CustomStringConvertible
@@ -93,8 +93,16 @@ extension MASError: CustomStringConvertible {
         case .noData:
             return "Service did not return data"
 
-        case .jsonParsing:
-            return "Unable to parse response JSON"
+        case .jsonParsing(let data):
+            if let data {
+                if let unparsable = String(data: data, encoding: .utf8) {
+                    return "Unable to parse response as JSON: \n\(unparsable)"
+                } else {
+                    return "Received defective response"
+                }
+            } else {
+                return "Received empty response"
+            }
         }
     }
 }

--- a/Tests/MasKitTests/Errors/MASErrorTestCase.swift
+++ b/Tests/MasKitTests/Errors/MASErrorTestCase.swift
@@ -122,7 +122,7 @@ class MASErrorTestCase: XCTestCase {
     }
 
     func testJsonParsing() {
-        error = .jsonParsing(error: nil)
-        XCTAssertEqual(error.description, "Unable to parse response JSON")
+        error = .jsonParsing(data: nil)
+        XCTAssertEqual(error.description, "Received empty response")
     }
 }


### PR DESCRIPTION
Output to stderr responses from Apple endpoints that are unparsable as JSON.

Includes a fix for an existing lint error.

Resolves #536