### PR TITLE
Fix breaking lint issue in MasStoreSearch.swift.

### DIFF
--- a/Sources/MasKit/Controllers/MasStoreSearch.swift
+++ b/Sources/MasKit/Controllers/MasStoreSearch.swift
@@ -122,8 +122,8 @@ class MasStoreSearch: StoreSearch {
         firstly {
             networkManager.loadData(from: pageUrl)
         }.map { data in
-            let html = String(decoding: data, as: UTF8.self)
-            guard let capture = MasStoreSearch.appVersionExpression.firstMatch(in: html)?.captures[0],
+            guard let html = String(data: data, encoding: .utf8),
+                let capture = MasStoreSearch.appVersionExpression.firstMatch(in: html)?.captures[0],
                 let version = Version(tolerant: capture)
             else {
                 return nil


### PR DESCRIPTION
Fix breaking lint issue in `MasStoreSearch.swift` in `main`.

Resolve #546