### PR TITLE
`outdated` checks if new app version requires newer macOS for all kinds of apps, not just mac-software

### DIFF
--- a/Sources/MasKit/Models/SearchResult.swift
+++ b/Sources/MasKit/Models/SearchResult.swift
@@ -10,7 +10,6 @@ struct SearchResult: Decodable {
     var bundleId: String
     var currentVersionReleaseDate: String
     var fileSizeBytes: String?
-    var kind: String
     var minimumOsVersion: String
     var price: Double?
     var sellerName: String
@@ -24,7 +23,6 @@ struct SearchResult: Decodable {
         bundleId: String = "",
         currentVersionReleaseDate: String = "",
         fileSizeBytes: String = "0",
-        kind: String = "",
         minimumOsVersion: String = "",
         price: Double = 0.0,
         sellerName: String = "",
@@ -37,7 +35,6 @@ struct SearchResult: Decodable {
         self.bundleId = bundleId
         self.currentVersionReleaseDate = currentVersionReleaseDate
         self.fileSizeBytes = fileSizeBytes
-        self.kind = kind
         self.minimumOsVersion = minimumOsVersion
         self.price = price
         self.sellerName = sellerName

--- a/Sources/MasKit/Models/SoftwareProduct.swift
+++ b/Sources/MasKit/Models/SoftwareProduct.swift
@@ -28,15 +28,13 @@ extension SoftwareProduct {
     /// - Parameter storeApp: App from search result.
     /// - Returns: true if the app is outdated; false otherwise.
     func isOutdatedWhenComparedTo(_ storeApp: SearchResult) -> Bool {
-        // Only look at min OS version if we have one, also only consider macOS apps
-        // Replace string literal with MasStoreSearch.Entity once `search` branch is merged.
-        if let osVersion = Version(tolerant: storeApp.minimumOsVersion), storeApp.kind == "mac-software" {
+        // If storeApp requires a version of macOS newer than the running version, do not consider self outdated.
+        if let osVersion = Version(tolerant: storeApp.minimumOsVersion) {
             let requiredVersion = OperatingSystemVersion(
                 majorVersion: osVersion.major,
                 minorVersion: osVersion.minor,
                 patchVersion: osVersion.patch
             )
-            // Don't consider an app outdated if the version in the app store requires a higher OS version.
             guard ProcessInfo.processInfo.isOperatingSystemAtLeast(requiredVersion) else {
                 return false
             }

--- a/Tests/MasKitTests/Models/SoftwareProductSpec.swift
+++ b/Tests/MasKitTests/Models/SoftwareProductSpec.swift
@@ -26,10 +26,10 @@ public class SoftwareProductSpec: QuickSpec {
                 itemIdentifier: 111
             )
 
-            let currentApp = SearchResult(kind: "mac-software", version: "1.0.0")
-            let appUpdate = SearchResult(kind: "mac-software", version: "2.0.0")
-            let higherOs = SearchResult(kind: "mac-software", minimumOsVersion: "99.0.0", version: "3.0.0")
-            let updateIos = SearchResult(kind: "software", minimumOsVersion: "99.0.0", version: "3.0.0")
+            let currentApp = SearchResult(version: "1.0.0")
+            let appUpdate = SearchResult(version: "2.0.0")
+            let higherOs = SearchResult(minimumOsVersion: "99.0.0", version: "3.0.0")
+            let updateIos = SearchResult(minimumOsVersion: "99.0.0", version: "3.0.0")
 
             it("is not outdated when there is no new version available") {
                 expect(app.isOutdatedWhenComparedTo(currentApp)) == false
@@ -37,11 +37,11 @@ public class SoftwareProductSpec: QuickSpec {
             it("is outdated when there is a new version available") {
                 expect(app.isOutdatedWhenComparedTo(appUpdate)) == true
             }
-            it("is not outdated when the new version requires a higher OS version") {
+            it("is not outdated when the new version of mac-software requires a higher OS version") {
                 expect(app.isOutdatedWhenComparedTo(higherOs)) == false
             }
-            it("ignores minimum iOS version") {
-                expect(app.isOutdatedWhenComparedTo(updateIos)) == true
+            it("is not outdated when the new version of software requires a higher OS version") {
+                expect(app.isOutdatedWhenComparedTo(updateIos)) == false
             }
         }
     }


### PR DESCRIPTION
`outdated` checks if new app version requires newer macOS for all kinds of apps, not just mac-software

Resolve #540