### PR TITLE
Re-enable `purchase`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ $ mas lucky twitter
 
 > Please note that this command will not allow you to install (or even purchase) an app for the first time:
 use the `purchase` command in that case.
-> ⛔ The `purchase` command is not supported as of macOS 10.15 Catalina. Please see [Known Issues](#%EF%B8%8F-known-issues).
 
 ```bash
 $ mas purchase 768053424
@@ -193,10 +192,9 @@ docs for more details.
 ## ⚠️ Known Issues
 
 Over time, Apple has changed the APIs used by `mas` to manage App Store apps, limiting its capabilities. Please sign in
-or purchase apps using the App Store app instead. Subsequent redownloads can be performed with `mas install`.
+using the App Store app instead. Subsequent redownloads can be performed with `mas install`.
 
 - ⛔️ The `signin` command is not supported as of macOS 10.13 High Sierra. [#164](https://github.com/mas-cli/mas/issues/164)
-- ⛔️ The `purchase` command is not supported as of macOS 10.15 Catalina. [#289](https://github.com/mas-cli/mas/issues/289)
 - ⛔️ The `account` command is not supported as of macOS 12 Monterey. [#417](https://github.com/mas-cli/mas/issues/417)
 
 The versions `mas` sees from the app bundles on your Mac don't always match the versions reported by the App Store for

--- a/Sources/MasKit/Commands/Purchase.swift
+++ b/Sources/MasKit/Commands/Purchase.swift
@@ -29,12 +29,6 @@ public struct PurchaseCommand: CommandProtocol {
 
     /// Runs the command.
     public func run(_ options: Options) -> Result<Void, MASError> {
-        if #available(macOS 10.15, *) {
-            // Purchases are no longer possible as of Catalina.
-            // https://github.com/mas-cli/mas/issues/289
-            return .failure(.notSupported)
-        }
-
         // Try to download applications with given identifiers and collect results
         let appIds = options.appIds.filter { appId in
             if let product = appLibrary.installedApp(forId: appId) {

--- a/Tests/MasKitTests/Commands/PurchaseCommandSpec.swift
+++ b/Tests/MasKitTests/Commands/PurchaseCommandSpec.swift
@@ -20,11 +20,7 @@ public class PurchaseCommandSpec: QuickSpec {
             it("purchases apps") {
                 let cmd = PurchaseCommand()
                 let result = cmd.run(PurchaseCommand.Options(appIds: []))
-                expect(result)
-                    .to(
-                        beFailure { error in
-                            expect(error) == .notSupported
-                        })
+                expect(result).to(beSuccess())
             }
         }
     }


### PR DESCRIPTION
`purchase` seems to work on macOS 12+. It was probably never broken. It was just misunderstood to allow purchasing of non-free apps, but that wasn't the case.

Resolve #289