### PR TITLE
Fix iTunes Search API issues

### DIFF
--- a/Sources/mas/Commands/Home.swift
+++ b/Sources/mas/Commands/Home.swift
@@ -10,7 +10,7 @@ import ArgumentParser
 
 extension Mas {
     /// Opens app page on MAS Preview. Uses the iTunes Lookup API:
-    /// https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/#lookup
+    /// https://performance-partners.apple.com/search-api
     struct Home: ParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Opens MAS Preview app page in a browser"

--- a/Sources/mas/Commands/Info.swift
+++ b/Sources/mas/Commands/Info.swift
@@ -11,7 +11,7 @@ import Foundation
 
 extension Mas {
     /// Displays app details. Uses the iTunes Lookup API:
-    /// https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/#lookup
+    /// https://performance-partners.apple.com/search-api
     struct Info: ParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Display app information from the Mac App Store"

--- a/Sources/mas/Commands/Open.swift
+++ b/Sources/mas/Commands/Open.swift
@@ -13,7 +13,7 @@ private let masScheme = "macappstore"
 
 extension Mas {
     /// Opens app page in MAS app. Uses the iTunes Lookup API:
-    /// https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/#lookup
+    /// https://performance-partners.apple.com/search-api
     struct Open: ParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Opens app page in AppStore.app"

--- a/Sources/mas/Commands/Search.swift
+++ b/Sources/mas/Commands/Search.swift
@@ -10,7 +10,7 @@ import ArgumentParser
 
 extension Mas {
     /// Search the Mac App Store using the iTunes Search API:
-    /// https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/
+    /// https://performance-partners.apple.com/search-api
     struct Search: ParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Search for apps from the Mac App Store"

--- a/Sources/mas/Commands/Vendor.swift
+++ b/Sources/mas/Commands/Vendor.swift
@@ -10,7 +10,7 @@ import ArgumentParser
 
 extension Mas {
     /// Opens vendor's app page in a browser. Uses the iTunes Lookup API:
-    /// https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/#lookup
+    /// https://performance-partners.apple.com/search-api
     struct Vendor: ParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Opens vendor's app page in a browser"

--- a/Sources/mas/Controllers/MasStoreSearch.swift
+++ b/Sources/mas/Controllers/MasStoreSearch.swift
@@ -19,7 +19,7 @@ class MasStoreSearch: StoreSearch {
     // into the App Store. Instead, we'll make an educated guess that it matches the currently
     // selected locale in macOS. This obviously isn't always going to match, but it's probably
     // better than passing no "country" at all to the iTunes Search API.
-    // https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/
+    // https://performance-partners.apple.com/search-api
     private let country: String?
     private let networkManager: NetworkManager
 

--- a/Sources/mas/Controllers/MasStoreSearch.swift
+++ b/Sources/mas/Controllers/MasStoreSearch.swift
@@ -40,7 +40,7 @@ class MasStoreSearch: StoreSearch {
     func search(for appName: String) -> Promise<[SearchResult]> {
         // Search for apps for compatible platforms, in order of preference.
         // Macs with Apple Silicon can run iPad and iPhone apps.
-        var entities = [Entity.macSoftware]
+        var entities = [Entity.desktopSoftware]
         if SysCtlSystemCommand.isAppleSilicon {
             entities += [.iPadSoftware, .iPhoneSoftware]
         }

--- a/Sources/mas/Controllers/StoreSearch.swift
+++ b/Sources/mas/Controllers/StoreSearch.swift
@@ -40,12 +40,13 @@ extension StoreSearch {
         components.queryItems = [
             URLQueryItem(name: "media", value: "software"),
             URLQueryItem(name: "entity", value: entity.rawValue),
-            URLQueryItem(name: "term", value: appName),
         ]
 
         if let country {
             components.queryItems!.append(URLQueryItem(name: "country", value: country))
         }
+
+        components.queryItems!.append(URLQueryItem(name: "term", value: appName))
 
         return components.url
     }
@@ -60,13 +61,15 @@ extension StoreSearch {
         }
 
         components.queryItems = [
-            URLQueryItem(name: "id", value: "\(appID)"),
+            URLQueryItem(name: "media", value: "software"),
             URLQueryItem(name: "entity", value: "desktopSoftware"),
         ]
 
         if let country {
             components.queryItems!.append(URLQueryItem(name: "country", value: country))
         }
+
+        components.queryItems!.append(URLQueryItem(name: "id", value: "\(appID)"))
 
         return components.url
     }

--- a/Sources/mas/Controllers/StoreSearch.swift
+++ b/Sources/mas/Controllers/StoreSearch.swift
@@ -16,6 +16,7 @@ protocol StoreSearch {
 }
 
 enum Entity: String {
+    case desktopSoftware
     case macSoftware
     case iPadSoftware
     case iPhoneSoftware = "software"
@@ -27,7 +28,11 @@ extension StoreSearch {
     ///
     /// - Parameter appName: MAS app identifier.
     /// - Returns: URL for the search service or nil if appName can't be encoded.
-    func searchURL(for appName: String, inCountry country: String?, ofEntity entity: Entity = .macSoftware) -> URL? {
+    func searchURL(
+        for appName: String,
+        inCountry country: String?,
+        ofEntity entity: Entity = .desktopSoftware
+    ) -> URL? {
         guard var components = URLComponents(string: "https://itunes.apple.com/search") else {
             return nil
         }

--- a/Tests/masTests/Controllers/MasStoreSearchSpec.swift
+++ b/Tests/masTests/Controllers/MasStoreSearchSpec.swift
@@ -18,17 +18,16 @@ public class MasStoreSearchSpec: QuickSpec {
         }
         describe("url string") {
             it("contains the app name") {
-                let appName = "myapp"
                 expect {
-                    MasStoreSearch().searchURL(for: appName, inCountry: "US")?.absoluteString
+                    MasStoreSearch().searchURL(for: "myapp", inCountry: "US")?.absoluteString
                 }
-                    == "https://itunes.apple.com/search?media=software&entity=macSoftware&term=\(appName)&country=US"
+                    == "https://itunes.apple.com/search?media=software&entity=desktopSoftware&term=myapp&country=US"
             }
             it("contains the encoded app name") {
                 expect {
                     MasStoreSearch().searchURL(for: "My App", inCountry: "US")?.absoluteString
                 }
-                    == "https://itunes.apple.com/search?media=software&entity=macSoftware&term=My%20App&country=US"
+                    == "https://itunes.apple.com/search?media=software&entity=desktopSoftware&term=My%20App&country=US"
             }
         }
         describe("store") {

--- a/Tests/masTests/Controllers/MasStoreSearchSpec.swift
+++ b/Tests/masTests/Controllers/MasStoreSearchSpec.swift
@@ -21,13 +21,13 @@ public class MasStoreSearchSpec: QuickSpec {
                 expect {
                     MasStoreSearch().searchURL(for: "myapp", inCountry: "US")?.absoluteString
                 }
-                    == "https://itunes.apple.com/search?media=software&entity=desktopSoftware&term=myapp&country=US"
+                    == "https://itunes.apple.com/search?media=software&entity=desktopSoftware&country=US&term=myapp"
             }
             it("contains the encoded app name") {
                 expect {
                     MasStoreSearch().searchURL(for: "My App", inCountry: "US")?.absoluteString
                 }
-                    == "https://itunes.apple.com/search?media=software&entity=desktopSoftware&term=My%20App&country=US"
+                    == "https://itunes.apple.com/search?media=software&entity=desktopSoftware&country=US&term=My%20App"
             }
         }
         describe("store") {


### PR DESCRIPTION
There are numerous problems with the integration with the iTunes Search API.

1. Add & use `Entity.desktopSoftware` instead of `macSoftware`. Former returns info (including version & description) that aligns with what is displayed in the App Store, while latter is at least sometimes out of alignment. Latter also seems to return any software that can run on a Mac (e.g., iOS, iPadOS, etc. software for Apple Silicon), seeming to default to iOS info. Probably better to get versions for each platform separately so we know what's for what platform.
2. Update iTunes Search API documentation URL to https://performance-partners.apple.com/search-api.
3. Add `media=software` query item to lookup URL to improve results.
4. Refactor `StoreSearch.lookup(…)` & `StoreSearch.search(…)` to share implementation, which deduplicates code & allows lookup to accept an `Entity` argument to get an app version for a specific platform instead of being hardcoded to `desktopSoftware`. Will help allow flags in the future to specify what platforms to check for apps.
5. Misc cleanup

Resolve #561