### PR TITLE
Downgrade Nimble & Quick to fix testing on newer Xcode versions.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "6416749c3c0488664fff6b42f8bf3ea8dc282ca1",
-        "version" : "13.6.0"
+        "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
+        "version" : "10.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Quick.git",
       "state" : {
-        "revision" : "1163a1b1b114a657c7432b63dd1f92ce99fe11a6",
-        "version" : "7.6.2"
+        "revision" : "f9d519828bb03dfc8125467d8f7b93131951124c",
+        "version" : "5.0.1"
       }
     },
     {
@@ -55,30 +55,12 @@
       }
     },
     {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
         "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Quick/Nimble.git", from: "13.6.0"),
-        .package(url: "https://github.com/Quick/Quick.git", from: "7.6.2"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "5.0.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
         .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.22.1"),
         .package(url: "https://github.com/mxcl/Version.git", from: "2.1.0"),

--- a/Tests/masTests/Commands/AccountSpec.swift
+++ b/Tests/masTests/Commands/AccountSpec.swift
@@ -13,7 +13,7 @@ import Quick
 
 // Deprecated test
 public class AccountSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/HomeSpec.swift
+++ b/Tests/masTests/Commands/HomeSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class HomeSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         let storeSearch = StoreSearchMock()
         let openCommand = OpenSystemCommandMock()
 

--- a/Tests/masTests/Commands/InfoSpec.swift
+++ b/Tests/masTests/Commands/InfoSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class InfoSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         let storeSearch = StoreSearchMock()
 
         beforeSuite {

--- a/Tests/masTests/Commands/InstallSpec.swift
+++ b/Tests/masTests/Commands/InstallSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class InstallSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/ListSpec.swift
+++ b/Tests/masTests/Commands/ListSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class ListSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/LuckySpec.swift
+++ b/Tests/masTests/Commands/LuckySpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class LuckySpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         let networkSession = NetworkSessionMockFromFile(responseFile: "search/slack.json")
         let storeSearch = MasStoreSearch(networkManager: NetworkManager(session: networkSession))
 

--- a/Tests/masTests/Commands/OpenSpec.swift
+++ b/Tests/masTests/Commands/OpenSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class OpenSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         let storeSearch = StoreSearchMock()
         let openCommand = OpenSystemCommandMock()
 

--- a/Tests/masTests/Commands/OutdatedSpec.swift
+++ b/Tests/masTests/Commands/OutdatedSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class OutdatedSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/PurchaseSpec.swift
+++ b/Tests/masTests/Commands/PurchaseSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class PurchaseSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/ResetSpec.swift
+++ b/Tests/masTests/Commands/ResetSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class ResetSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/SearchSpec.swift
+++ b/Tests/masTests/Commands/SearchSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class SearchSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         let storeSearch = StoreSearchMock()
 
         beforeSuite {

--- a/Tests/masTests/Commands/SignInSpec.swift
+++ b/Tests/masTests/Commands/SignInSpec.swift
@@ -13,7 +13,7 @@ import Quick
 
 // Deprecated test
 public class SignInSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/SignOutSpec.swift
+++ b/Tests/masTests/Commands/SignOutSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class SignOutSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/UninstallSpec.swift
+++ b/Tests/masTests/Commands/UninstallSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class UninstallSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/UpgradeSpec.swift
+++ b/Tests/masTests/Commands/UpgradeSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class UpgradeSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Commands/VendorSpec.swift
+++ b/Tests/masTests/Commands/VendorSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class VendorSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         let storeSearch = StoreSearchMock()
         let openCommand = OpenSystemCommandMock()
 

--- a/Tests/masTests/Commands/VersionSpec.swift
+++ b/Tests/masTests/Commands/VersionSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class VersionSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Controllers/MasAppLibrarySpec.swift
+++ b/Tests/masTests/Controllers/MasAppLibrarySpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class MasAppLibrarySpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         let library = MasAppLibrary(softwareMap: SoftwareMapMock(products: apps))
 
         beforeSuite {

--- a/Tests/masTests/Controllers/MasStoreSearchSpec.swift
+++ b/Tests/masTests/Controllers/MasStoreSearchSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class MasStoreSearchSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/ExternalCommands/OpenSystemCommandSpec.swift
+++ b/Tests/masTests/ExternalCommands/OpenSystemCommandSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class OpenSystemCommandSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Formatters/AppListFormatterSpec.swift
+++ b/Tests/masTests/Formatters/AppListFormatterSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class AppListsFormatterSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         // static func reference
         let format = AppListFormatter.format(products:)
         var products: [SoftwareProduct] = []

--- a/Tests/masTests/Formatters/SearchResultFormatterSpec.swift
+++ b/Tests/masTests/Formatters/SearchResultFormatterSpec.swift
@@ -12,7 +12,7 @@ import Quick
 @testable import mas
 
 public class SearchResultsFormatterSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         // static func reference
         let format = SearchResultFormatter.format(results:includePrice:)
         var results: [SearchResult] = []

--- a/Tests/masTests/Models/SearchResultListSpec.swift
+++ b/Tests/masTests/Models/SearchResultListSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class SearchResultListSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Models/SearchResultSpec.swift
+++ b/Tests/masTests/Models/SearchResultSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class SearchResultSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }

--- a/Tests/masTests/Models/SoftwareProductSpec.swift
+++ b/Tests/masTests/Models/SoftwareProductSpec.swift
@@ -13,7 +13,7 @@ import Quick
 @testable import mas
 
 public class SoftwareProductSpec: QuickSpec {
-    override public static func spec() {
+    override public func spec() {
         beforeSuite {
             Mas.initialize()
         }


### PR DESCRIPTION
Downgrade Nimble & Quick to fix testing on newer Xcode versions.

Resolve #583