### PR TITLE
Improve GitHub runners

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
     # https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     # https://github.com/mas-cli/mas/actions/runners
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     # https://github.com/actions/checkout#usage

--- a/Brewfile
+++ b/Brewfile
@@ -5,10 +5,8 @@ brew "swift-format"
 brew "swiftformat"
 brew "trash"
 
-# Already installed on GitHub Actions runner.
-# brew "swiftlint"
-
-tap "peripheryapp/periphery"
 if OS.mac? && MacOS.version >= :ventura
+  brew "swiftlint"
+  tap "peripheryapp/periphery"
   cask "periphery"
 end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -20,8 +20,3 @@ printf $'==> 👢 Bootstrapping (%s)\n' "$(script/version)"
 # Install Homebrew tools
 rm -f Brewfile.lock.json
 brew bundle install --no-upgrade --verbose
-
-# swiftlint is already installed on GitHub Actions runners.
-if [[ ! -x "$(command -v swiftlint)" ]]; then
-  brew install swiftlint
-fi

--- a/script/lint
+++ b/script/lint
@@ -30,14 +30,14 @@ done
 
 exit_code=0
 for source in Package.swift Sources Tests; do
-  printf -- $'--> 🕊  %s swift-format\n' "${source}"
+  printf -- $'--> 🦅 %s swift-format\n' "${source}"
   swift-format lint --strict --recursive "${source}"
   ((exit_code |= "${?}"))
-  printf -- $'--> 🕊  %s swiftformat\n' "${source}"
+  printf -- $'--> 🦅 %s swiftformat\n' "${source}"
   script -q /dev/null swiftformat --lint --strict "${source}" |
-    (grep -vxE $'Running SwiftFormat\\.\\.\\.\r|\\(lint mode - no files will be changed\\.\\)\r|Reading (?:config|swift-version) file at .*|\033\[32mSwiftFormat completed in \\d+\\.\\d+s\\.\033\\[0m\r|0/\\d+ files require formatting\\.\r' || true)
+    (grep -vxE '(?:\^D\x08{2})?Running SwiftFormat\.{3}\r|\(lint mode - no files will be changed\.\)\r|Reading (?:config|swift-version) file at .*|\x1b\[32mSwiftFormat completed in \d+\.\d+s\.\x1b\[0m\r|0/\d+ files require formatting\.\r' || true)
   ((exit_code |= "${?}"))
-  printf -- $'--> 🕊  %s swiftlint\n' "${source}"
+  printf -- $'--> 🦅 %s swiftlint\n' "${source}"
   swiftlint --strict --quiet "${source}" 2> \
     >((grep -vxF $'warning: Configuration option \'allow_multiline_func\' in \'opening_brace\' rule is deprecated. Use the option \'ignore_multiline_function_signatures\' instead.' || true) >&2)
   ((exit_code |= "${?}"))
@@ -66,7 +66,7 @@ PAGER='cat' git diff --check
 
 printf -- $'--> 🌀 Periphery\n'
 script -q /dev/null periphery scan --strict --quiet --disable-update-check |
-  (grep -vxF $'\033[0;1;32m* \033[0;0m\033[0;1mNo unused code detected.\033[0;0m\r\n' || true)
+  (grep -vxE '(?:\x1b\[0;1;32m|\^D\x08{2})\* (?:\x1b\[0;0m\x1b\[0;1m)?No unused code detected\.(?:\x1b\[0;0m)?\r' || true)
 ((exit_code |= "${?}"))
 
 exit "${exit_code}"


### PR DESCRIPTION
Improve GitHub runners:

- Upgrade GitHub runners from `macos-14` to `macos-15`.
- Suppress useless `swiftformat` output on GitHub runners.
- Change Swift bird emoji to ensure consistent spacing.
- Install `swiftlint` & `peripheryapp/periphery` tap via `Brewfile` iff macOS >= 13 (install breaks on macOS <= 12).

Resolve #594