### PR TITLE
Additional improvements enabled by macOS 10.13

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mxcl/PromiseKit.git",
       "state" : {
-        "revision" : "8a98e31a47854d3180882c8068cc4d9381bf382d",
-        "version" : "6.22.1"
+        "revision" : "6fcc08077124e9747f1ec7bd8bb78f5caffe5a79",
+        "version" : "8.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "5.0.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
-        .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.22.1"),
+        .package(url: "https://github.com/mxcl/PromiseKit.git", from: "8.1.2"),
         .package(url: "https://github.com/mxcl/Version.git", from: "2.1.0"),
         .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.1"),
     ],

--- a/Sources/mas/Formatters/AppInfoFormatter.swift
+++ b/Sources/mas/Formatters/AppInfoFormatter.swift
@@ -47,12 +47,8 @@ enum AppInfoFormatter {
     /// - Parameter serverDate: String containing a date in ISO-8601 format.
     /// - Returns: Simple date format.
     private static func humanReadableDate(_ serverDate: String) -> String {
-        let serverDateFormatter = DateFormatter()
-        serverDateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        serverDateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-
-        let humanDateFormatter = DateFormatter()
-        humanDateFormatter.dateFormat = "yyyy-MM-dd"
-        return serverDateFormatter.date(from: serverDate).flatMap(humanDateFormatter.string(from:)) ?? ""
+        let humanDateFormatter = ISO8601DateFormatter()
+        humanDateFormatter.formatOptions = [.withFullDate]
+        return ISO8601DateFormatter().date(from: serverDate).map(humanDateFormatter.string(from:)) ?? ""
     }
 }


### PR DESCRIPTION
Additional improvements enabled by macOS 10.13:

- Upgrade PromiseKit to 8.1.2 (current)
- Use `ISO8601DateFormatter`

Resolve #613