### PR TITLE
Fix JSON parsing error by making `formattedPrice` & `price` optional for `SearchResult`

### DIFF
--- a/Sources/mas/Formatters/AppInfoFormatter.swift
+++ b/Sources/mas/Formatters/AppInfoFormatter.swift
@@ -18,7 +18,7 @@ enum AppInfoFormatter {
         let headline = [
             "\(app.trackName)",
             "\(app.version)",
-            "[\(app.formattedPrice)]",
+            "[\(app.displayPrice)]",
         ]
         .joined(separator: " ")
 

--- a/Sources/mas/Formatters/SearchResultFormatter.swift
+++ b/Sources/mas/Formatters/SearchResultFormatter.swift
@@ -29,7 +29,7 @@ enum SearchResultFormatter {
             let version = result.version
 
             if includePrice {
-                output += String(format: "%12lu  %@  (%@)  %@\n", appID, appName, version, result.formattedPrice)
+                output += String(format: "%12lu  %@  (%@)  %@\n", appID, appName, version, result.displayPrice)
             } else {
                 output += String(format: "%12lu  %@  (%@)\n", appID, appName, version)
             }

--- a/Sources/mas/Models/SearchResult.swift
+++ b/Sources/mas/Models/SearchResult.swift
@@ -10,15 +10,19 @@ struct SearchResult: Decodable {
     var bundleId: String
     var currentVersionReleaseDate: String
     var fileSizeBytes: String
-    var formattedPrice: String
+    var formattedPrice: String?
     var minimumOsVersion: String
-    var price: Double
+    var price: Double?
     var sellerName: String
     var sellerUrl: String?
     var trackId: AppID
     var trackName: String
     var trackViewUrl: String
     var version: String
+
+    var displayPrice: String {
+        formattedPrice ?? "Unknown"
+    }
 
     init(
         bundleId: String = "",


### PR DESCRIPTION
Fix JSON parsing error by making `formattedPrice` & `price` optional for `SearchResult`.

Use new `displayPrice` to get around optional `formattedPrice`. Doesn't handle i18n, but we can clean that up after we completely redo JSON handling.

Resolve #493