### PR TITLE
Replace `appNameOrBundleIdentifier` & all output `appName` with `displayName`

### DIFF
--- a/Sources/mas/Commands/Install.swift
+++ b/Sources/mas/Commands/Install.swift
@@ -29,8 +29,8 @@ extension MAS {
         func run(appLibrary: AppLibrary, searcher: AppStoreSearcher) throws {
             // Try to download applications with given identifiers and collect results
             let appIDs = appIDs.filter { appID in
-                if let appName = appLibrary.installedApps(withAppID: appID).first?.appName, !force {
-                    printWarning("\(appName) is already installed")
+                if let displayName = appLibrary.installedApps(withAppID: appID).first?.displayName, !force {
+                    printWarning("\(displayName) is already installed")
                     return false
                 }
 

--- a/Sources/mas/Commands/Lucky.swift
+++ b/Sources/mas/Commands/Lucky.swift
@@ -61,8 +61,8 @@ extension MAS {
         /// - Throws: Any error that occurs while attempting to install the app.
         private func install(appID: AppID, appLibrary: AppLibrary) throws {
             // Try to download applications with given identifiers and collect results
-            if let appName = appLibrary.installedApps(withAppID: appID).first?.appName, !force {
-                printWarning("\(appName) is already installed")
+            if let displayName = appLibrary.installedApps(withAppID: appID).first?.displayName, !force {
+                printWarning("\(displayName) is already installed")
             } else {
                 do {
                     try downloadApps(withAppIDs: [appID]).wait()

--- a/Sources/mas/Commands/Outdated.swift
+++ b/Sources/mas/Commands/Outdated.swift
@@ -35,7 +35,7 @@ extension MAS {
                                 if installedApp.isOutdatedWhenComparedTo(storeApp) {
                                     print(
                                         """
-                                        \(installedApp.itemIdentifier) \(installedApp.appName) \
+                                        \(installedApp.itemIdentifier) \(installedApp.displayName) \
                                         (\(installedApp.bundleVersion) -> \(storeApp.version))
                                         """
                                     )
@@ -50,7 +50,7 @@ extension MAS {
                                     printWarning(
                                         """
                                         Identifier \(installedApp.itemIdentifier) not found in store. \
-                                        Was expected to identify \(installedApp.appName).
+                                        Was expected to identify \(installedApp.displayName).
                                         """
                                     )
                                 }

--- a/Sources/mas/Commands/Purchase.swift
+++ b/Sources/mas/Commands/Purchase.swift
@@ -26,8 +26,8 @@ extension MAS {
         func run(appLibrary: AppLibrary, searcher: AppStoreSearcher) throws {
             // Try to download applications with given identifiers and collect results
             let appIDs = appIDs.filter { appID in
-                if let appName = appLibrary.installedApps(withAppID: appID).first?.appName {
-                    printWarning("\(appName) has already been purchased.")
+                if let displayName = appLibrary.installedApps(withAppID: appID).first?.displayName {
+                    printWarning("\(displayName) has already been purchased.")
                     return false
                 }
 

--- a/Sources/mas/Commands/Uninstall.swift
+++ b/Sources/mas/Commands/Uninstall.swift
@@ -50,7 +50,7 @@ extension MAS {
 
             if dryRun {
                 for installedApp in installedApps {
-                    printInfo("'\(installedApp.appName)' '\(installedApp.bundlePath)'")
+                    printInfo("'\(installedApp.displayName)' '\(installedApp.bundlePath)'")
                 }
                 printInfo("(not removed, dry run)")
             } else {

--- a/Sources/mas/Commands/Upgrade.swift
+++ b/Sources/mas/Commands/Upgrade.swift
@@ -39,12 +39,14 @@ extension MAS {
 
             print("Upgrading \(apps.count) outdated application\(apps.count > 1 ? "s" : ""):")
             print(
-                apps.map { "\($0.installedApp.appName) (\($0.installedApp.bundleVersion)) -> (\($0.storeApp.version))" }
-                    .joined(separator: "\n")
+                apps.map { installedApp, storeApp in
+                    "\(storeApp.trackName) (\(installedApp.bundleVersion)) -> (\(storeApp.version))"
+                }
+                .joined(separator: "\n")
             )
 
             do {
-                try downloadApps(withAppIDs: apps.map(\.installedApp.itemIdentifier.appIDValue)).wait()
+                try downloadApps(withAppIDs: apps.map(\.storeApp.trackId)).wait()
             } catch {
                 throw error as? MASError ?? .downloadFailed(error: error as NSError)
             }

--- a/Sources/mas/Formatters/AppListFormatter.swift
+++ b/Sources/mas/Formatters/AppListFormatter.swift
@@ -11,25 +11,24 @@ import Foundation
 /// Formats text output for the search command.
 enum AppListFormatter {
     static let idColumnMinWidth = 10
-    static let nameColumnMinWidth = 50
 
     /// Formats text output with list results.
     ///
     /// - Parameter products: List of software products app data.
     /// - Returns: Multiline text output.
     static func format(products: [SoftwareProduct]) -> String {
-        // find longest appName for formatting, default 50
-        let maxLength = products.map(\.appNameOrBundleIdentifier.count).max() ?? nameColumnMinWidth
+        // find longest displayName for formatting
+        let maxLength = products.map(\.displayName.count).max() ?? 0
 
         var output = ""
 
         for product in products {
             let appID = product.itemIdentifier.stringValue
                 .padding(toLength: idColumnMinWidth, withPad: " ", startingAt: 0)
-            let appName = product.appNameOrBundleIdentifier.padding(toLength: maxLength, withPad: " ", startingAt: 0)
+            let displayName = product.displayName.padding(toLength: maxLength, withPad: " ", startingAt: 0)
             let version = product.bundleVersion
 
-            output += "\(appID)  \(appName)  (\(version))\n"
+            output += "\(appID)  \(displayName)  (\(version))\n"
         }
 
         return output.trimmingCharacters(in: .newlines)

--- a/Sources/mas/Models/SearchResult.swift
+++ b/Sources/mas/Models/SearchResult.swift
@@ -17,7 +17,9 @@ struct SearchResult: Decodable {
     var trackName = ""
     var trackViewUrl = ""
     var version = ""
+}
 
+extension SearchResult {
     var displayPrice: String {
         formattedPrice ?? "Unknown"
     }

--- a/Sources/mas/Models/SoftwareProduct.swift
+++ b/Sources/mas/Models/SoftwareProduct.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Regex
 import Version
 
 /// Protocol describing the members of CKSoftwareProduct used throughout mas.
@@ -18,10 +19,13 @@ protocol SoftwareProduct {
     var itemIdentifier: NSNumber { get set }
 }
 
+private let appNameFromBundlePathRegex = Regex(#"[^/]+(?=\.app$)"#)
+
 extension SoftwareProduct {
-    /// - Returns: bundleIdentifier if appName is empty string.
-    var appNameOrBundleIdentifier: String {
-        appName.isEmpty ? bundleIdentifier : appName
+    var displayName: String {
+        appName.isEmpty
+            ? appNameFromBundlePathRegex.firstMatch(in: bundlePath)?.matchedString ?? bundleIdentifier
+            : appName
     }
 
     /// Determines whether the app is considered outdated.


### PR DESCRIPTION
Replace `appNameOrBundleIdentifier` & all output `appName` with `displayName`, which provides better fallback values for the app name.

Minor code cleanup.

Resolve #480