### PR TITLE
Cleanup 1.9.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -11,7 +11,7 @@ body:
     id: config
     attributes:
       label: mas config
-      description: The output of `mas config --markdown`
+      description: Output of `mas config --markdown`
       value: |
         <!--
         If `mas config --markdown` runs without error, replace the contents of this text area with its output.
@@ -60,7 +60,8 @@ body:
     id: reproduction
     attributes:
       label: Steps to reproduce
-      description: Copy, paste & format commands & output in the console block (as instructed below)
+      description: |
+        Copied, pasted & formatted commands & output in console blocks (as instructed below); instructions; screenshots
       value: |
         ```console
 
@@ -78,7 +79,7 @@ body:
 
         Format commands & output as follows (where `…` is a placeholder):
 
-        - Use a multiline console block: start with ```` ```console ````, end with ```` ``` ````, each on its own line
+        - Use a console block: start with ```` ```console ````, end with ```` ``` ````, each on its own line
         - Prefix each non-console step (or comment) with two hashes & a space: `## …`
         - Remove custom shell prompts; instead, prefix each console command with a dollar sign & a space: `$ …`
         - Prefix each output line beginning with `#`, `$`, `%`, or `>` with an additional instance of that <!--
@@ -89,9 +90,11 @@ body:
 
         ````text
         ```console
-        ## In the Mac App Store GUI, …
+        ## In the Mac App Store GUI, click on…
         $ mas list
         123  App 1  (4.5.6)
         124  App 2  (10.2)
+        $ mas outdated
+        123 App 1 (4.5.6 -> 4.5.7)
         ```
         ````

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,9 @@
 name: CodeQL
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
   schedule:
     - cron: 44 14 * * 4
   workflow_dispatch:

--- a/Sources/mas/Commands/Config.swift
+++ b/Sources/mas/Commands/Config.swift
@@ -29,19 +29,19 @@ extension MAS {
             print(
                 """
                 mas ▁▁▁▁ \(Package.version)
+                arch ▁▁▁ \(configStringValue("hw.machine"))
                 from ▁▁▁ \(Package.installMethod)
                 origin ▁ \(Package.gitOrigin)
                 rev ▁▁▁▁ \(Package.gitRevision)
-                swift ▁▁ \(Package.swiftVersion)
                 driver ▁ \(Package.swiftDriverVersion)
+                swift ▁▁ \(Package.swiftVersion)
                 region ▁ \(Storefront.isoRegion?.alpha2 ?? unknown)
                 macos ▁▁ \(
                     ProcessInfo.processInfo.operatingSystemVersionString.dropFirst(8)
                         .replacingOccurrences(of: "Build ", with: "")
                 )
-                mac ▁▁▁▁ \(macModel())
-                cpu ▁▁▁▁ \(cpuBrandString())
-                arch ▁▁▁ \(architecture())
+                mac ▁▁▁▁ \(configStringValue("hw.product"))
+                cpu ▁▁▁▁ \(configStringValue("machdep.cpu.brand_string"))
                 """
             )
             if markdown {
@@ -51,34 +51,8 @@ extension MAS {
     }
 }
 
-private func macModel() -> String {
-    var name = [CTL_HW, HW_MODEL]
-
-    var size = 0
-    guard sysctl(&name, u_int(name.count), nil, &size, nil, 0) == 0 else {
-        perror("sysctl")
-        return unknown
-    }
-
-    var buffer = [CChar](repeating: 0, count: size)
-    guard sysctl(&name, u_int(name.count), &buffer, &size, nil, 0) == 0 else {
-        perror("sysctl")
-        return unknown
-    }
-
-    return String(cString: buffer)
-}
-
-private func cpuBrandString() -> String {
-    configValue("machdep.cpu.brand_string")
-}
-
-private func architecture() -> String {
-    configValue("hw.machine")
-}
-
-private func configValue(_ name: String) -> String {
-    var size = 0
+private func configStringValue(_ name: String) -> String {
+    var size = MemoryLayout<Int32>.size
     guard sysctlbyname(name, nil, &size, nil, 0) == 0 else {
         perror("sysctlbyname")
         return unknown

--- a/script/lint
+++ b/script/lint
@@ -14,7 +14,7 @@
 
 printf $'==> 🚨 Linting mas %s\n' "$(script/version)"
 
-script/generate_package_swift
+script/generate_package_swift lint
 
 for linter in git markdownlint periphery shellcheck swift-format swiftformat swiftlint yamllint; do
   if ! command -v "${linter}" >/dev/null; then

--- a/script/test
+++ b/script/test
@@ -10,7 +10,7 @@
 
 printf $'==> ✅ Testing mas %s\n' "$(script/version)"
 
-script/generate_package_swift
+script/generate_package_swift test
 
 script -q /dev/null swift test "${@}" |
   (grep -vxE $'Test Suite \'.+\' (?:started|passed) at \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\.?\\r|Test Case \'-\\[.+\\]\' (?:started|passed \\(\\d+\\.\\d+ seconds\\))\\.\\r|\\t Executed \\d+ tests?, with 0 failures \\(0 unexpected\\) in \\d+\\.\\d+ \\(\\d+\\.\\d+\\) seconds\\r' || true)


### PR DESCRIPTION
- Improve `mas config`:
  - Reorder `mas config` output.
  - Set `Package.installMethod` from `script/lint` & `script/test`.
  - Simplify & consolidate `sysctl` value reading for `mas config`.
- Improve Bug Report form text.
- Only run CodeQL for the `main` branch.

Resolve #701