### PR TITLE
Use `MAS_DIRTY_INDICATOR` environment variable to set the dirty workspace indicator for the version output by `script/version`

### DIFF
--- a/script/version
+++ b/script/version
@@ -10,4 +10,4 @@
 
 printf $'%s%s\n'\
  "${"$(git describe --tags 2>/dev/null)"#v}"\
- "${"$(git diff-index HEAD --;git ls-files --exclude-standard --others)":++}"
+ "${"$(git diff-index HEAD --;git ls-files --exclude-standard --others)":+"${MAS_DIRTY_INDICATOR-+}"}"


### PR DESCRIPTION
Use `MAS_DIRTY_INDICATOR` environment variable to set the dirty workspace indicator for the version output by `script/version`.

Resolve #703