### PR TITLE
Improve scripts

### DIFF
--- a/script/_setup_script
+++ b/script/_setup_script
@@ -6,7 +6,7 @@
 # Boilerplate setup for scripts.
 #
 
-\unalias -as
+builtin unalias -as
 setopt\
  autopushd\
  combiningchars\

--- a/script/clean
+++ b/script/clean
@@ -8,7 +8,7 @@
 
 . "${0:a:h}/_setup_script"
 
-printf $'==> 🗑 Cleaning mas %s\n' "$(script/version)"
+printf $'==> 🗑​ Cleaning mas %s\n' "$(script/version)"
 
 swift package clean
 swift package reset


### PR DESCRIPTION
Use `builtin` instead of `\` in scripts.

Improve logging emoji spacing.

Resolve #715