### PR TITLE
Improve `script/test` boilerplate filtering for newer `swift` executables.

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -14,7 +14,6 @@
   "maximumBlankLines": 1,
   "multiElementCollectionTrailingCommas": true,
   "prioritizeKeepingFunctionOutputTogether": true,
-  "reflowMultilineStringLiterals": true,
   "respectsExistingLineBreaks": true,
   "rules": {
     "AllPublicDeclarationsHaveDocumentation": true,

--- a/Brewfile
+++ b/Brewfile
@@ -5,8 +5,7 @@ brew "swiftformat"
 brew "yamllint"
 
 if OS.mac? && MacOS.version >= :ventura
+  brew "periphery"
   brew "swift-format"
   brew "swiftlint"
-  tap "peripheryapp/periphery"
-  cask "periphery"
 end

--- a/Tests/masTests/.swift-format
+++ b/Tests/masTests/.swift-format
@@ -14,7 +14,6 @@
   "maximumBlankLines": 1,
   "multiElementCollectionTrailingCommas": true,
   "prioritizeKeepingFunctionOutputTogether": true,
-  "reflowMultilineStringLiterals": true,
   "respectsExistingLineBreaks": true,
   "rules": {
     "AllPublicDeclarationsHaveDocumentation": false,

--- a/script/format
+++ b/script/format
@@ -24,7 +24,7 @@ for source in Package.swift Sources Tests; do
   swift-format format --in-place --recursive "${source}"
   printf -- $'--> 🦅 %s swiftformat\n' "${source}"
   script -q /dev/null swiftformat --strict "${source}" |
-    (grep -vxE '(?:\^D\x08{2})?Running SwiftFormat\.{3}\r|Reading (?:config|swift-version) file at .*|\x1b\[32mSwiftFormat completed in \d+\.\d+s\.\x1b\[0m\r|0/\d+ files formatted\.\r' || true)
+    (grep -vxE '(?:\^D\x08{2})?Running SwiftFormat\.{3}\r|Reading (?:config|swift-version) file at .*|\x1b\[32mSwiftFormat completed in \d+(?:\.\d+)?s\.\x1b\[0m\r|0/\d+ files formatted\.\r' || true)
   printf -- $'--> 🦅 %s swiftlint\n' "${source}"
   swiftlint --fix --quiet "${source}"
 done

--- a/script/lint
+++ b/script/lint
@@ -30,7 +30,7 @@ for source in Package.swift Sources Tests; do
   ((exit_code |= ${?}))
   printf -- $'--> 🦅 %s swiftformat\n' "${source}"
   script -q /dev/null swiftformat --lint --strict "${source}" |
-    (grep -vxE '(?:\^D\x08{2})?Running SwiftFormat\.{3}\r|\(lint mode - no files will be changed\.\)\r|Reading (?:config|swift-version) file at .*|\x1b\[32mSwiftFormat completed in \d+\.\d+s\.\x1b\[0m\r|0/\d+ files require formatting\.\r' || true)
+    (grep -vxE '(?:\^D\x08{2})?Running SwiftFormat\.{3}\r|\(lint mode - no files will be changed\.\)\r|Reading (?:config|swift-version) file at .*|\x1b\[32mSwiftFormat completed in \d+(?:\.\d+)?s\.\x1b\[0m\r|0/\d+ files require formatting\.\r' || true)
   ((exit_code |= ${?}))
   printf -- $'--> 🦅 %s swiftlint\n' "${source}"
   swiftlint --strict --quiet "${source}"

--- a/script/test
+++ b/script/test
@@ -13,4 +13,4 @@ printf $'==> 🧪 Testing mas %s\n' "$(script/version)"
 script/generate_package_swift test
 
 script -q /dev/null swift test "${@}" |
-  (grep -vxE $'Test Suite \'.+\' (?:started|passed) at \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\.?\\r|Test Case \'-\\[.+\\]\' (?:started|passed \\(\\d+\\.\\d+ seconds\\))\\.\\r|\\t Executed \\d+ tests?, with 0 failures \\(0 unexpected\\) in \\d+\\.\\d+ \\(\\d+\\.\\d+\\) seconds\\r' || true)
+  (grep -vxE $'Test Suite \'.+\' (?:started|passed) at \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\.?\\r|Test Case \'-\\[.+\\]\' (?:started|(?:passed|skipped) \\(\\d+\\.\\d+ seconds\\))\\.\\r|.+:\\d+: -\\[.+\\] : Test was filtered out\\.\\r|\\t Executed \\d+ tests?, with (?:\\d+ tests? skipped and )?0 failures \\(0 unexpected\\) in \\d+\\.\\d+ \\(\\d+\\.\\d+\\) seconds\\r' || true)

--- a/script/version
+++ b/script/version
@@ -14,7 +14,7 @@ if [[ "${branch}" = HEAD ]]; then
   if git merge-base --is-ancestor HEAD main; then
     branch=
   else
-    branch="${"${(@)"${(fnO)"$(git branch --format '%(ahead-behind:HEAD) %(refname:short)')"}"[1]}"##* }"
+    branch="${"${(@)"${(fnO)"$(git branch --contains HEAD --format '%(ahead-behind:HEAD) %(refname:short)')"}"[1]}"##* }"
   fi
 fi
 


### PR DESCRIPTION
Improve `script/test` boilerplate filtering for newer `swift` executables.

Resolve #731