### PR TITLE
Require macOS 10.15+ to run mas.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "mas",
     platforms: [
-        .macOS(.v10_13)
+        .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo port install mas
 
 We provide a [custom Homebrew tap](https://github.com/mas-cli/homebrew-tap) with pre-built bottles
 for all macOS versions since 10.11 (El Capitan). The newest versions of mas, however, are only available
-for macOS 10.13+ (High Sierra or newer).
+for macOS 10.15+ (Catalina or newer).
 
 To install mas from our tap:
 

--- a/Sources/mas/AppStore/Storefront.swift
+++ b/Sources/mas/AppStore/Storefront.swift
@@ -10,10 +10,8 @@ import StoreKit
 
 enum Storefront {
     static var isoRegion: ISORegion? {
-        if #available(macOS 10.15, *) {
-            if let storefront = SKPaymentQueue.default().storefront {
-                return findISORegion(forAlpha3Code: storefront.countryCode)
-            }
+        if let storefront = SKPaymentQueue.default().storefront {
+            return findISORegion(forAlpha3Code: storefront.countryCode)
         }
 
         guard let alpha2 = Locale.autoupdatingCurrent.regionCode else {

--- a/Sources/mas/Commands/Open.swift
+++ b/Sources/mas/Commands/Open.swift
@@ -48,15 +48,10 @@ private func openMacAppStore() -> Promise<Void> {
             throw MASError.notSupported
         }
 
-        if #available(macOS 10.15, *) {
-            NSWorkspace.shared.openApplication(at: appURL, configuration: NSWorkspace.OpenConfiguration()) { _, error in
-                if let error {
-                    seal.reject(error)
-                }
-                seal.fulfill(())
+        NSWorkspace.shared.openApplication(at: appURL, configuration: NSWorkspace.OpenConfiguration()) { _, error in
+            if let error {
+                seal.reject(error)
             }
-        } else {
-            try NSWorkspace.shared.launchApplication(at: appURL, configuration: [:])
             seal.fulfill(())
         }
     }

--- a/Sources/mas/Network/URL.swift
+++ b/Sources/mas/Network/URL.swift
@@ -12,18 +12,10 @@ import PromiseKit
 extension URL {
     func open() -> Promise<Void> {
         Promise { seal in
-            if #available(macOS 10.15, *) {
-                NSWorkspace.shared.open(self, configuration: NSWorkspace.OpenConfiguration()) { _, error in
-                    if let error {
-                        seal.reject(error)
-                    }
-                    seal.fulfill(())
+            NSWorkspace.shared.open(self, configuration: NSWorkspace.OpenConfiguration()) { _, error in
+                if let error {
+                    seal.reject(error)
                 }
-            } else {
-                guard NSWorkspace.shared.open(self) else {
-                    throw MASError.runtimeError("Failed to open \(self)")
-                }
-
                 seal.fulfill(())
             }
         }

--- a/script/package
+++ b/script/package
@@ -38,7 +38,7 @@ productbuild \
     <options customize="never" require-scripts="false"/>
     <volume-check>
         <allowed-os-versions>
-            <os-version min="10.13"/>
+            <os-version min="10.15"/>
         </allowed-os-versions>
     </volume-check>
     <choices-outline>


### PR DESCRIPTION
Require macOS 10.15+ to run mas.

Resolve #612