### PR TITLE
Do not prepend any branch prefix to the version if the main branch does not exist

### DIFF
--- a/script/version
+++ b/script/version
@@ -11,7 +11,7 @@
 branch="${"$(git rev-parse --abbrev-ref HEAD)":/main}"
 
 if [[ "${branch}" = HEAD ]]; then
-  if git merge-base --is-ancestor HEAD main; then
+  if ! git show-ref --verify --quiet refs/heads/main || git merge-base --is-ancestor HEAD main; then
     branch=
   else
     branch="${"${(@)"${(fnO)"$(git branch --contains HEAD --format '%(ahead-behind:HEAD) %(refname:short)')"}"[1]}"##* }"


### PR DESCRIPTION
Do not prepend any branch prefix to the version if the main branch does not exist.

Resolve #751