### PR TITLE
Ignore major & minor updates for Quick in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     schedule:
       interval: daily
     directory: /
+    ignore:
+      - dependency-name: quick
+        update-types: [major, minor]
     labels: [📚 dependencies]
     commit-message:
       prefix: ⬆️


### PR DESCRIPTION
Ignore major & minor updates for Quick in Dependabot since we're stuck on old Quick 7.5.x until 7.6+ is fixed.