### PR TITLE
Enable Dependabot checks for Quick

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
     schedule:
       interval: daily
     directory: /
-    ignore:
-      - dependency-name: quick
-        update-types: [major, minor]
     labels: [📚 dependencies]
     commit-message:
       prefix: ⬆️


### PR DESCRIPTION
Enable Dependabot checks for Quick.

Resolve #762