### PR TITLE
Code cleanup

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,10 +13,8 @@ disabled_rules:
   # eventually enable
   - file_header
   - one_declaration_per_file
-  - prefer_key_path
   - trailing_comma
   # never enable
-  - closure_body_length
   - contrasted_opening_brace
   - explicit_acl
   - explicit_enum_raw_value
@@ -28,6 +26,8 @@ disabled_rules:
   - prefixed_toplevel_constant
   - sorted_enum_cases
   - vertical_whitespace_between_cases
+closure_body_length:
+  warning: 40
 file_name:
   excluded: [Finder.swift, Utilities.swift]
 file_types_order:

--- a/Sources/mas/AppStore/CKSoftwareProduct+SoftwareProduct.swift
+++ b/Sources/mas/AppStore/CKSoftwareProduct+SoftwareProduct.swift
@@ -8,7 +8,6 @@
 
 import StoreFoundation
 
-// MARK: - SoftwareProduct
 extension CKSoftwareProduct: SoftwareProduct, @retroactive @unchecked Sendable {
     var appID: AppID {
         get { itemIdentifier.appIDValue }

--- a/Sources/mas/AppStore/CKSoftwareProduct+SoftwareProduct.swift
+++ b/Sources/mas/AppStore/CKSoftwareProduct+SoftwareProduct.swift
@@ -9,4 +9,10 @@
 import StoreFoundation
 
 // MARK: - SoftwareProduct
-extension CKSoftwareProduct: SoftwareProduct, @retroactive @unchecked Sendable {}
+extension CKSoftwareProduct: SoftwareProduct, @retroactive @unchecked Sendable {
+    var appID: AppID {
+        get { itemIdentifier.appIDValue }
+        // swiftlint:disable:next legacy_objc_type
+        set { itemIdentifier = NSNumber(value: newValue) }
+    }
+}

--- a/Sources/mas/AppStore/Downloader.swift
+++ b/Sources/mas/AppStore/Downloader.swift
@@ -26,12 +26,8 @@ func downloadApps(
     for appID in appIDs {
         do {
             _ = try await searcher.lookup(appID: appID)
-        } catch {
-            guard case MASError.unknownAppID = error else {
-                throw error
-            }
-
-            printWarning("App ID \(appID) not found in Mac App Store.")
+        } catch MASError.unknownAppID(let unknownAppID) {
+            printWarning("App ID \(unknownAppID) not found in Mac App Store.")
             continue
         }
         try await downloadApp(withAppID: appID, purchasing: purchasing, withAttemptCount: 3)

--- a/Sources/mas/AppStore/Downloader.swift
+++ b/Sources/mas/AppStore/Downloader.swift
@@ -65,7 +65,7 @@ private func downloadApp(withAppID appID: AppID, purchasing: Bool, withAttemptCo
 
         let attemptCount = attemptCount - 1
         printWarning(downloadError.localizedDescription)
-        printWarning("Trying again up to \(attemptCount) more \(attemptCount == 1 ? "time" : "times").")
+        printWarning("Retrying… \(attemptCount) attempt\(attemptCount == 1 ? "" : "s") remaining.")
         try await downloadApp(withAppID: appID, purchasing: purchasing, withAttemptCount: attemptCount)
     }
 }

--- a/Sources/mas/AppStore/Downloader.swift
+++ b/Sources/mas/AppStore/Downloader.swift
@@ -57,13 +57,14 @@ private func downloadApp(withAppID appID: AppID, purchasing: Bool, withAttemptCo
         // If the download failed due to network issues, try again. Otherwise, fail immediately.
         guard
             case MASError.downloadFailed(let downloadError) = error,
-            case NSURLErrorDomain = downloadError?.domain
+            let downloadError,
+            downloadError.domain == NSURLErrorDomain
         else {
             throw error
         }
 
         let attemptCount = attemptCount - 1
-        printWarning((downloadError ?? error).localizedDescription)
+        printWarning(downloadError.localizedDescription)
         printWarning("Trying again up to \(attemptCount) more \(attemptCount == 1 ? "time" : "times").")
         try await downloadApp(withAppID: appID, purchasing: purchasing, withAttemptCount: attemptCount)
     }

--- a/Sources/mas/AppStore/PurchaseDownloadObserver.swift
+++ b/Sources/mas/AppStore/PurchaseDownloadObserver.swift
@@ -8,10 +8,10 @@
 
 import CommerceKit
 
-private let downloadingPhase = 0 as Int64
-private let installingPhase = 1 as Int64
-private let initialPhase = 4 as Int64
-private let downloadedPhase = 5 as Int64
+private let downloadingPhaseType = 0 as Int64
+private let installingPhaseType = 1 as Int64
+private let initialPhaseType = 4 as Int64
+private let downloadedPhaseType = 5 as Int64
 
 class PurchaseDownloadObserver: CKDownloadQueueObserver {
     private let appID: AppID
@@ -40,17 +40,17 @@ class PurchaseDownloadObserver: CKDownloadQueueObserver {
         } else {
             if priorPhaseType != status.activePhase.phaseType {
                 switch status.activePhase.phaseType {
-                case downloadingPhase:
-                    if priorPhaseType == initialPhase {
+                case downloadingPhaseType:
+                    if priorPhaseType == initialPhaseType {
                         clearLine()
                         printInfo("Downloading \(download.progressDescription)")
                     }
-                case downloadedPhase:
-                    if priorPhaseType == downloadingPhase {
+                case downloadedPhaseType:
+                    if priorPhaseType == downloadingPhaseType {
                         clearLine()
                         printInfo("Downloaded \(download.progressDescription)")
                     }
-                case installingPhase:
+                case installingPhaseType:
                     clearLine()
                     printInfo("Installing \(download.progressDescription)")
                 default:
@@ -124,9 +124,9 @@ private extension SSDownloadStatus {
 private extension SSDownloadPhase {
     var phaseDescription: String {
         switch phaseType {
-        case downloadingPhase:
+        case downloadingPhaseType:
             "Downloading"
-        case installingPhase:
+        case installingPhaseType:
             "Installing"
         default:
             "Waiting"

--- a/Sources/mas/AppStore/PurchaseDownloadObserver.swift
+++ b/Sources/mas/AppStore/PurchaseDownloadObserver.swift
@@ -139,7 +139,9 @@ private extension SSDownloadPhase {
 extension PurchaseDownloadObserver {
     func observeDownloadQueue(_ downloadQueue: CKDownloadQueue = CKDownloadQueue.shared()) async throws {
         let observerID = downloadQueue.add(self)
-        defer { downloadQueue.remove(observerID) }
+        defer {
+            downloadQueue.remove(observerID)
+        }
 
         try await withCheckedThrowingContinuation { continuation in
             completionHandler = {

--- a/Sources/mas/AppStore/PurchaseDownloadObserver.swift
+++ b/Sources/mas/AppStore/PurchaseDownloadObserver.swift
@@ -38,8 +38,10 @@ class PurchaseDownloadObserver: CKDownloadQueueObserver {
         if status.isFailed || status.isCancelled {
             queue.removeDownload(withItemIdentifier: download.metadata.itemIdentifier)
         } else {
-            if prevPhaseType != status.activePhase.phaseType {
-                switch status.activePhase.phaseType {
+            let currPhaseType = status.activePhase.phaseType
+            let prevPhaseType = prevPhaseType
+            if prevPhaseType != currPhaseType {
+                switch currPhaseType {
                 case downloadingPhaseType:
                     if prevPhaseType == initialPhaseType {
                         clearLine()
@@ -56,7 +58,7 @@ class PurchaseDownloadObserver: CKDownloadQueueObserver {
                 default:
                     break
                 }
-                prevPhaseType = status.activePhase.phaseType
+                self.prevPhaseType = currPhaseType
             }
             progress(status.progressState)
         }

--- a/Sources/mas/AppStore/PurchaseDownloadObserver.swift
+++ b/Sources/mas/AppStore/PurchaseDownloadObserver.swift
@@ -17,7 +17,7 @@ class PurchaseDownloadObserver: CKDownloadQueueObserver {
     private let appID: AppID
     private var completionHandler: (() -> Void)?
     private var errorHandler: ((MASError) -> Void)?
-    private var priorPhaseType: Int64?
+    private var prevPhaseType: Int64?
 
     init(appID: AppID) {
         self.appID = appID
@@ -38,15 +38,15 @@ class PurchaseDownloadObserver: CKDownloadQueueObserver {
         if status.isFailed || status.isCancelled {
             queue.removeDownload(withItemIdentifier: download.metadata.itemIdentifier)
         } else {
-            if priorPhaseType != status.activePhase.phaseType {
+            if prevPhaseType != status.activePhase.phaseType {
                 switch status.activePhase.phaseType {
                 case downloadingPhaseType:
-                    if priorPhaseType == initialPhaseType {
+                    if prevPhaseType == initialPhaseType {
                         clearLine()
                         printInfo("Downloading \(download.progressDescription)")
                     }
                 case downloadedPhaseType:
-                    if priorPhaseType == downloadingPhaseType {
+                    if prevPhaseType == downloadingPhaseType {
                         clearLine()
                         printInfo("Downloaded \(download.progressDescription)")
                     }
@@ -56,7 +56,7 @@ class PurchaseDownloadObserver: CKDownloadQueueObserver {
                 default:
                     break
                 }
-                priorPhaseType = status.activePhase.phaseType
+                prevPhaseType = status.activePhase.phaseType
             }
             progress(status.progressState)
         }

--- a/Sources/mas/AppStore/PurchaseDownloadObserver.swift
+++ b/Sources/mas/AppStore/PurchaseDownloadObserver.swift
@@ -145,9 +145,13 @@ extension PurchaseDownloadObserver {
 
         try await withCheckedThrowingContinuation { continuation in
             completionHandler = {
+                self.completionHandler = nil
+                self.errorHandler = nil
                 continuation.resume()
             }
             errorHandler = { error in
+                self.completionHandler = nil
+                self.errorHandler = nil
                 continuation.resume(throwing: error)
             }
         }

--- a/Sources/mas/Commands/Account.swift
+++ b/Sources/mas/Commands/Account.swift
@@ -25,8 +25,10 @@ extension MAS {
 
             do {
                 print(try ISStoreAccount.primaryAccount.identifier)
+            } catch let error as MASError {
+                throw error
             } catch {
-                throw error as? MASError ?? MASError.failed(error: error as NSError)
+                throw MASError.failed(error: error as NSError)
             }
         }
     }

--- a/Sources/mas/Commands/Info.swift
+++ b/Sources/mas/Commands/Info.swift
@@ -27,8 +27,10 @@ extension MAS {
         func run(searcher: AppStoreSearcher) async throws {
             do {
                 print(AppInfoFormatter.format(app: try await searcher.lookup(appID: appID)))
+            } catch let error as MASError {
+                throw error
             } catch {
-                throw error as? MASError ?? .searchFailed
+                throw MASError.searchFailed
             }
         }
     }

--- a/Sources/mas/Commands/Install.swift
+++ b/Sources/mas/Commands/Install.swift
@@ -39,8 +39,10 @@ extension MAS {
 
             do {
                 try await downloadApps(withAppIDs: appIDs, verifiedBy: searcher)
+            } catch let error as MASError {
+                throw error
             } catch {
-                throw error as? MASError ?? .downloadFailed(error: error as NSError)
+                throw MASError.downloadFailed(error: error as NSError)
             }
         }
     }

--- a/Sources/mas/Commands/Lucky.swift
+++ b/Sources/mas/Commands/Lucky.swift
@@ -42,8 +42,10 @@ extension MAS {
                 }
 
                 appID = result.trackId
+            } catch let error as MASError {
+                throw error
             } catch {
-                throw error as? MASError ?? .searchFailed
+                throw MASError.searchFailed
             }
 
             guard let appID else {
@@ -66,8 +68,10 @@ extension MAS {
             } else {
                 do {
                     try await downloadApps(withAppIDs: [appID])
+                } catch let error as MASError {
+                    throw error
                 } catch {
-                    throw error as? MASError ?? .downloadFailed(error: error as NSError)
+                    throw MASError.downloadFailed(error: error as NSError)
                 }
             }
         }

--- a/Sources/mas/Commands/Outdated.swift
+++ b/Sources/mas/Commands/Outdated.swift
@@ -36,11 +36,11 @@ extension MAS {
                             """
                         )
                     }
-                } catch MASError.unknownAppID(_) {
+                } catch MASError.unknownAppID(let unknownAppID) {
                     if verbose {
                         printWarning(
                             """
-                            Identifier \(installedApp.itemIdentifier) not found in store. \
+                            Identifier \(unknownAppID) not found in store. \
                             Was expected to identify \(installedApp.appName).
                             """
                         )

--- a/Sources/mas/Commands/Outdated.swift
+++ b/Sources/mas/Commands/Outdated.swift
@@ -27,11 +27,11 @@ extension MAS {
         func run(appLibrary: AppLibrary, searcher: AppStoreSearcher) async throws {
             for installedApp in appLibrary.installedApps {
                 do {
-                    let storeApp = try await searcher.lookup(appID: installedApp.itemIdentifier.appIDValue)
+                    let storeApp = try await searcher.lookup(appID: installedApp.appID)
                     if installedApp.isOutdated(comparedTo: storeApp) {
                         print(
                             """
-                            \(installedApp.itemIdentifier) \(installedApp.appName) \
+                            \(installedApp.appID) \(installedApp.appName) \
                             (\(installedApp.bundleVersion) -> \(storeApp.version))
                             """
                         )

--- a/Sources/mas/Commands/Purchase.swift
+++ b/Sources/mas/Commands/Purchase.swift
@@ -36,8 +36,10 @@ extension MAS {
 
             do {
                 try await downloadApps(withAppIDs: appIDs, verifiedBy: searcher, purchasing: true)
+            } catch let error as MASError {
+                throw error
             } catch {
-                throw error as? MASError ?? .downloadFailed(error: error as NSError)
+                throw MASError.downloadFailed(error: error as NSError)
             }
         }
     }

--- a/Sources/mas/Commands/Search.swift
+++ b/Sources/mas/Commands/Search.swift
@@ -34,8 +34,10 @@ extension MAS {
 
                 let output = SearchResultFormatter.format(results: results, includePrice: price)
                 print(output)
+            } catch let error as MASError {
+                throw error
             } catch {
-                throw error as? MASError ?? .searchFailed
+                throw MASError.searchFailed
             }
         }
     }

--- a/Sources/mas/Commands/SignIn.swift
+++ b/Sources/mas/Commands/SignIn.swift
@@ -27,8 +27,10 @@ extension MAS {
         func run() throws {
             do {
                 _ = try ISStoreAccount.signIn(appleID: appleID, password: password, systemDialog: dialog)
+            } catch let error as MASError {
+                throw error
             } catch {
-                throw error as? MASError ?? MASError.signInFailed(error: error as NSError)
+                throw MASError.signInFailed(error: error as NSError)
             }
         }
     }

--- a/Sources/mas/Commands/Upgrade.swift
+++ b/Sources/mas/Commands/Upgrade.swift
@@ -44,8 +44,10 @@ extension MAS {
 
             do {
                 try await downloadApps(withAppIDs: apps.map(\.storeApp.trackId))
+            } catch let error as MASError {
+                throw error
             } catch {
-                throw error as? MASError ?? .downloadFailed(error: error as NSError)
+                throw MASError.downloadFailed(error: error as NSError)
             }
         }
 
@@ -81,20 +83,17 @@ extension MAS {
                     if installedApp.isOutdated(comparedTo: storeApp) {
                         outdatedApps.append((installedApp, storeApp))
                     }
-                } catch {
-                    guard case MASError.unknownAppID = error else {
-                        printError(String(describing: error))
-                        continue
-                    }
-
+                } catch MASError.unknownAppID(let unknownAppID) {
                     if verbose {
                         printWarning(
                             """
-                            Identifier \(installedApp.itemIdentifier) not found in store. \
+                            Identifier \(unknownAppID) not found in store. \
                             Was expected to identify \(installedApp.appName).
                             """
                         )
                     }
+                } catch {
+                    printError(String(describing: error))
                 }
             }
             return outdatedApps

--- a/Sources/mas/Commands/Upgrade.swift
+++ b/Sources/mas/Commands/Upgrade.swift
@@ -79,7 +79,7 @@ extension MAS {
             var outdatedApps = [(SoftwareProduct, SearchResult)]()
             for installedApp in apps {
                 do {
-                    let storeApp = try await searcher.lookup(appID: installedApp.itemIdentifier.appIDValue)
+                    let storeApp = try await searcher.lookup(appID: installedApp.appID)
                     if installedApp.isOutdated(comparedTo: storeApp) {
                         outdatedApps.append((installedApp, storeApp))
                     }

--- a/Sources/mas/Commands/Upgrade.swift
+++ b/Sources/mas/Commands/Upgrade.swift
@@ -93,7 +93,7 @@ extension MAS {
                         )
                     }
                 } catch {
-                    printError(String(describing: error))
+                    printError(error)
                 }
             }
             return outdatedApps

--- a/Sources/mas/Controllers/AppLibrary.swift
+++ b/Sources/mas/Controllers/AppLibrary.swift
@@ -27,9 +27,7 @@ extension AppLibrary {
     /// - Parameter appID: app ID for app(s).
     /// - Returns: [SoftwareProduct] of matching apps.
     func installedApps(withAppID appID: AppID) -> [SoftwareProduct] {
-        // swiftlint:disable:next legacy_objc_type
-        let appID = NSNumber(value: appID)
-        return installedApps.filter { $0.itemIdentifier == appID }
+        installedApps.filter { $0.appID == appID }
     }
 
     /// Finds all installed instances of apps whose name is `appName`.

--- a/Sources/mas/Controllers/SpotlightSoftwareMap.swift
+++ b/Sources/mas/Controllers/SpotlightSoftwareMap.swift
@@ -42,20 +42,20 @@ class SpotlightSoftwareMap: SoftwareMap {
 
                 continuation.resume(
                     returning: query.results.compactMap { result in
-                        if let result = result as? NSMetadataItem {
+                        if let item = result as? NSMetadataItem {
                             // swift-format-ignore
                             SimpleSoftwareProduct(
                                 appID:
-                                    result.value(forAttribute: "kMDItemAppStoreAdamID") as? AppID ?? 0,
+                                    item.value(forAttribute: "kMDItemAppStoreAdamID") as? AppID ?? 0,
                                 appName:
-                                    (result.value(forAttribute: "_kMDItemDisplayNameWithExtensions") as? String ?? "")
+                                    (item.value(forAttribute: "_kMDItemDisplayNameWithExtensions") as? String ?? "")
                                     .removeSuffix(".app"),
                                 bundleIdentifier:
-                                    result.value(forAttribute: kMDItemCFBundleIdentifier as String) as? String ?? "",
+                                    item.value(forAttribute: kMDItemCFBundleIdentifier as String) as? String ?? "",
                                 bundlePath:
-                                    result.value(forAttribute: kMDItemPath as String) as? String ?? "",
+                                    item.value(forAttribute: kMDItemPath as String) as? String ?? "",
                                 bundleVersion:
-                                    result.value(forAttribute: kMDItemVersion as String) as? String ?? ""
+                                    item.value(forAttribute: kMDItemVersion as String) as? String ?? ""
                             )
                         } else {
                             nil

--- a/Sources/mas/Controllers/SpotlightSoftwareMap.swift
+++ b/Sources/mas/Controllers/SpotlightSoftwareMap.swift
@@ -45,6 +45,8 @@ class SpotlightSoftwareMap: SoftwareMap {
                         if let result = result as? NSMetadataItem {
                             // swift-format-ignore
                             SimpleSoftwareProduct(
+                                appID:
+                                    result.value(forAttribute: "kMDItemAppStoreAdamID") as? AppID ?? 0,
                                 appName:
                                     (result.value(forAttribute: "_kMDItemDisplayNameWithExtensions") as? String ?? "")
                                     .removeSuffix(".app"),
@@ -53,10 +55,7 @@ class SpotlightSoftwareMap: SoftwareMap {
                                 bundlePath:
                                     result.value(forAttribute: kMDItemPath as String) as? String ?? "",
                                 bundleVersion:
-                                    result.value(forAttribute: kMDItemVersion as String) as? String ?? "",
-                                itemIdentifier:
-                                    // swiftlint:disable:next legacy_objc_type
-                                    result.value(forAttribute: "kMDItemAppStoreAdamID") as? NSNumber ?? 0
+                                    result.value(forAttribute: kMDItemVersion as String) as? String ?? ""
                             )
                         } else {
                             nil

--- a/Sources/mas/Errors/MASError.swift
+++ b/Sources/mas/Errors/MASError.swift
@@ -40,7 +40,6 @@ enum MASError: Error, Equatable {
     case jsonParsing(data: Data)
 }
 
-// MARK: - CustomStringConvertible
 extension MASError: CustomStringConvertible {
     var description: String {
         switch self {

--- a/Sources/mas/Formatters/AppInfoFormatter.swift
+++ b/Sources/mas/Formatters/AppInfoFormatter.swift
@@ -15,15 +15,13 @@ enum AppInfoFormatter {
     /// - Parameter app: Search result with app data.
     /// - Returns: Multiline text output.
     static func format(app: SearchResult) -> String {
-        let headline = [
-            "\(app.trackName)",
-            "\(app.version)",
-            "[\(app.displayPrice)]",
-        ]
-        .joined(separator: " ")
-
-        return [
-            headline,
+        [
+            [
+                "\(app.trackName)",
+                "\(app.version)",
+                "[\(app.displayPrice)]",
+            ]
+            .joined(separator: " "),
             "By: \(app.sellerName)",
             "Released: \(humanReadableDate(app.currentVersionReleaseDate))",
             "Minimum OS: \(app.minimumOsVersion)",
@@ -38,8 +36,7 @@ enum AppInfoFormatter {
     /// - Parameter size: Numeric string.
     /// - Returns: Formatted file size description.
     private static func humanReadableSize(_ size: String) -> String {
-        let bytesSize = Int64(size) ?? 0
-        return ByteCountFormatter.string(fromByteCount: bytesSize, countStyle: .file)
+        ByteCountFormatter.string(fromByteCount: Int64(size) ?? 0, countStyle: .file)
     }
 
     /// Formats a date in  format.

--- a/Sources/mas/Formatters/AppListFormatter.swift
+++ b/Sources/mas/Formatters/AppListFormatter.swift
@@ -21,8 +21,7 @@ enum AppListFormatter {
         var output = ""
 
         for product in products {
-            let appID = product.itemIdentifier.stringValue
-                .padding(toLength: idColumnMinWidth, withPad: " ", startingAt: 0)
+            let appID = product.appID.description.padding(toLength: idColumnMinWidth, withPad: " ", startingAt: 0)
             let appName = product.appName.padding(toLength: maxLength, withPad: " ", startingAt: 0)
             let version = product.bundleVersion
 

--- a/Sources/mas/Formatters/Utilities.swift
+++ b/Sources/mas/Formatters/Utilities.swift
@@ -26,44 +26,41 @@ func print(_ message: String, to fileHandle: FileHandle) {
 
 /// Prints to stdout prefixed with a blue arrow.
 func printInfo(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-    guard isatty(fileno(stdout)) != 0 else {
+    if isatty(fileno(stdout)) != 0 {
+        // Blue bold arrow, Bold text
+        print(
+            "\(csi)1;34m==>\(csi)0m \(csi)1m\(message(items, separator: separator, terminator: terminator))\(csi)0m",
+            terminator: ""
+        )
+    } else {
         print("==> \(message(items, separator: separator, terminator: terminator))", terminator: "")
-        return
     }
-
-    // Blue bold arrow, Bold text
-    print(
-        "\(csi)1;34m==>\(csi)0m \(csi)1m\(message(items, separator: separator, terminator: terminator))\(csi)0m",
-        terminator: ""
-    )
 }
 
 /// Prints to stderr prefixed with "Warning:" underlined in yellow.
 func printWarning(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-    guard isatty(fileno(stderr)) != 0 else {
+    if isatty(fileno(stderr)) != 0 {
+        // Yellow, underlined "Warning:" prefix
+        print(
+            "\(csi)4;33mWarning:\(csi)0m \(message(items, separator: separator, terminator: terminator))",
+            to: FileHandle.standardError
+        )
+    } else {
         print("Warning: \(message(items, separator: separator, terminator: terminator))", to: FileHandle.standardError)
-        return
     }
-
-    // Yellow, underlined "Warning:" prefix
-    print(
-        "\(csi)4;33mWarning:\(csi)0m \(message(items, separator: separator, terminator: terminator))",
-        to: FileHandle.standardError
-    )
 }
 
 /// Prints to stderr prefixed with "Error:" underlined in red.
 func printError(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-    guard isatty(fileno(stderr)) != 0 else {
+    if isatty(fileno(stderr)) != 0 {
+        // Red, underlined "Error:" prefix
+        print(
+            "\(csi)4;31mError:\(csi)0m \(message(items, separator: separator, terminator: terminator))",
+            to: FileHandle.standardError
+        )
+    } else {
         print("Error: \(message(items, separator: separator, terminator: terminator))", to: FileHandle.standardError)
-        return
     }
-
-    // Red, underlined "Error:" prefix
-    print(
-        "\(csi)4;31mError:\(csi)0m \(message(items, separator: separator, terminator: terminator))",
-        to: FileHandle.standardError
-    )
 }
 
 private func message(_ items: Any..., separator: String = " ", terminator: String = "\n") -> String {
@@ -72,10 +69,8 @@ private func message(_ items: Any..., separator: String = " ", terminator: Strin
 
 /// Flushes stdout.
 func clearLine() {
-    guard isatty(fileno(stdout)) != 0 else {
-        return
+    if isatty(fileno(stdout)) != 0 {
+        print("\(csi)2K\(csi)0G", terminator: "")
+        fflush(stdout)
     }
-
-    print("\(csi)2K\(csi)0G", terminator: "")
-    fflush(stdout)
 }

--- a/Sources/mas/Models/SimpleSoftwareProduct.swift
+++ b/Sources/mas/Models/SimpleSoftwareProduct.swift
@@ -9,10 +9,9 @@
 import Foundation
 
 struct SimpleSoftwareProduct: SoftwareProduct {
+    var appID: AppID
     var appName: String
     var bundleIdentifier: String
     var bundlePath: String
     var bundleVersion: String
-    // swiftlint:disable:next legacy_objc_type
-    var itemIdentifier: NSNumber
 }

--- a/Sources/mas/Models/SoftwareProduct.swift
+++ b/Sources/mas/Models/SoftwareProduct.swift
@@ -11,13 +11,12 @@ import Version
 
 /// Protocol describing the members of CKSoftwareProduct used throughout mas.
 protocol SoftwareProduct: Sendable {
+    var appID: AppID { get set }
     var appName: String { get }
     // periphery:ignore
     var bundleIdentifier: String { get set }
     var bundlePath: String { get set }
     var bundleVersion: String { get set }
-    // swiftlint:disable:next legacy_objc_type
-    var itemIdentifier: NSNumber { get set }
 }
 
 extension SoftwareProduct {

--- a/Sources/mas/Network/NetworkManager.swift
+++ b/Sources/mas/Network/NetworkManager.swift
@@ -23,7 +23,7 @@ struct NetworkManager {
             let url = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Caches/com.mphys.mas-cli")
             try FileManager.default.removeItem(at: url)
         } catch {
-            // Ignore
+            // do nothing
         }
     }
 

--- a/Tests/masTests/.swiftlint.yml
+++ b/Tests/masTests/.swiftlint.yml
@@ -7,12 +7,16 @@
 # https://github.com/realm/SwiftLint#configuration
 #
 ---
+opt_in_rules:
+  - closure_body_length
 disabled_rules:
-  - force_cast
   - force_try
-  - function_body_length
-  - implicitly_unwrapped_optional
-  - large_tuple
-  - quick_discouraged_call
   - quick_discouraged_pending_test
   - required_deinit
+closure_body_length:
+  warning: 80
+function_body_length:
+  warning: 80
+large_tuple:
+  warning: 5
+  error: 10

--- a/Tests/masTests/.swiftlint.yml
+++ b/Tests/masTests/.swiftlint.yml
@@ -13,7 +13,6 @@ disabled_rules:
   - function_body_length
   - implicitly_unwrapped_optional
   - large_tuple
-  - legacy_objc_type
   - quick_discouraged_call
   - quick_discouraged_pending_test
   - required_deinit

--- a/Tests/masTests/Commands/OutdatedSpec.swift
+++ b/Tests/masTests/Commands/OutdatedSpec.swift
@@ -35,11 +35,11 @@ public final class OutdatedSpec: AsyncSpec {
                             .run(
                                 appLibrary: MockAppLibrary(
                                     SimpleSoftwareProduct(
+                                        appID: mockSearchResult.trackId,
                                         appName: mockSearchResult.trackName,
                                         bundleIdentifier: "au.id.haroldchu.mac.Bandwidth",
                                         bundlePath: "/Applications/Bandwidth+.app",
-                                        bundleVersion: "1.27",
-                                        itemIdentifier: NSNumber(value: mockSearchResult.trackId)
+                                        bundleVersion: "1.27"
                                     )
                                 ),
                                 searcher: MockAppStoreSearcher([mockSearchResult.trackId: mockSearchResult])

--- a/Tests/masTests/Commands/UninstallSpec.swift
+++ b/Tests/masTests/Commands/UninstallSpec.swift
@@ -25,32 +25,50 @@ public final class UninstallSpec: AsyncSpec {
 
         xdescribe("uninstall command") {
             context("dry run") {
-                let uninstall = try! MAS.Uninstall.parse(["--dry-run", String(appID)])
-
                 it("can't remove a missing app") {
-                    await expecta(await consequencesOf(try uninstall.run(appLibrary: MockAppLibrary())))
+                    await expecta(
+                        await consequencesOf(
+                            try await MAS.Uninstall.parse(["--dry-run", String(appID)])
+                                .run(appLibrary: MockAppLibrary())
+                        )
+                    )
                         == (MASError.notInstalled(appID: appID), "", "")
                 }
                 it("finds an app") {
-                    await expecta(await consequencesOf(try uninstall.run(appLibrary: MockAppLibrary(app))))
+                    await expecta(
+                        await consequencesOf(
+                            try await MAS.Uninstall.parse(["--dry-run", String(appID)])
+                                .run(appLibrary: MockAppLibrary(app))
+                        )
+                    )
                         == (nil, "==> 'Some App' '/tmp/Some.app'\n==> (not removed, dry run)\n", "")
                 }
             }
             context("wet run") {
-                let uninstall = try! MAS.Uninstall.parse([String(appID)])
-
                 it("can't remove a missing app") {
-                    await expecta(await consequencesOf(try uninstall.run(appLibrary: MockAppLibrary())))
+                    await expecta(
+                        await consequencesOf(
+                            try await MAS.Uninstall.parse([String(appID)]).run(appLibrary: MockAppLibrary())
+                        )
+                    )
                         == (MASError.notInstalled(appID: appID), "", "")
                 }
                 it("removes an app") {
-                    await expecta(await consequencesOf(try uninstall.run(appLibrary: MockAppLibrary(app))))
+                    await expecta(
+                        await consequencesOf(
+                            try await MAS.Uninstall.parse([String(appID)]).run(appLibrary: MockAppLibrary(app))
+                        )
+                    )
                         == (nil, "", "")
                 }
                 it("fails if there is a problem with the trash command") {
                     var brokenApp = app
                     brokenApp.bundlePath = "/dev/null"
-                    await expecta(await consequencesOf(try uninstall.run(appLibrary: MockAppLibrary(brokenApp))))
+                    await expecta(
+                        await consequencesOf(
+                            try await MAS.Uninstall.parse([String(appID)]).run(appLibrary: MockAppLibrary(brokenApp))
+                        )
+                    )
                         == (MASError.uninstallFailed(error: nil), "", "")
                 }
             }

--- a/Tests/masTests/Commands/UninstallSpec.swift
+++ b/Tests/masTests/Commands/UninstallSpec.swift
@@ -16,11 +16,11 @@ public final class UninstallSpec: AsyncSpec {
     override public static func spec() {
         let appID = 12345 as AppID
         let app = SimpleSoftwareProduct(
+            appID: appID,
             appName: "Some App",
             bundleIdentifier: "com.some.app",
             bundlePath: "/tmp/Some.app",
-            bundleVersion: "1.0",
-            itemIdentifier: NSNumber(value: appID)
+            bundleVersion: "1.0"
         )
 
         xdescribe("uninstall command") {

--- a/Tests/masTests/Formatters/AppListFormatterSpec.swift
+++ b/Tests/masTests/Formatters/AppListFormatterSpec.swift
@@ -22,11 +22,11 @@ public final class AppListFormatterSpec: AsyncSpec {
             }
             it("can format a single product") {
                 let product = SimpleSoftwareProduct(
+                    appID: 12345,
                     appName: "Awesome App",
                     bundleIdentifier: "",
                     bundlePath: "",
-                    bundleVersion: "19.2.1",
-                    itemIdentifier: 12345
+                    bundleVersion: "19.2.1"
                 )
                 await expecta(await consequencesOf(format([product])))
                     == ("12345       Awesome App  (19.2.1)", nil, "", "")
@@ -37,18 +37,18 @@ public final class AppListFormatterSpec: AsyncSpec {
                         format(
                             [
                                 SimpleSoftwareProduct(
+                                    appID: 12345,
                                     appName: "Awesome App",
                                     bundleIdentifier: "",
                                     bundlePath: "",
-                                    bundleVersion: "19.2.1",
-                                    itemIdentifier: 12345
+                                    bundleVersion: "19.2.1"
                                 ),
                                 SimpleSoftwareProduct(
+                                    appID: 67890,
                                     appName: "Even Better App",
                                     bundleIdentifier: "",
                                     bundlePath: "",
-                                    bundleVersion: "1.2.0",
-                                    itemIdentifier: 67890
+                                    bundleVersion: "1.2.0"
                                 ),
                             ]
                         )

--- a/Tests/masTests/Models/SoftwareProductSpec.swift
+++ b/Tests/masTests/Models/SoftwareProductSpec.swift
@@ -14,11 +14,11 @@ import Quick
 public final class SoftwareProductSpec: AsyncSpec {
     override public static func spec() {
         let app = SimpleSoftwareProduct(
+            appID: 111,
             appName: "App",
             bundleIdentifier: "",
             bundlePath: "",
-            bundleVersion: "1.0.0",
-            itemIdentifier: 111
+            bundleVersion: "1.0.0"
         )
 
         describe("software product") {


### PR DESCRIPTION
Code cleanup:

- Use `appID: AppID` instead of `itemIdentifier: NSNumber`
- Set handlers to `nil` in `PurchaseDownloadObserver`
- Improve download retry warning
- Improve SwiftLint config
- Improve syntax
- Improve variable names

Resolve #775