### PR TITLE
Warn about how to index installed apps when no apps found by `mas list`

### DIFF
--- a/Sources/mas/Commands/List.swift
+++ b/Sources/mas/Commands/List.swift
@@ -22,7 +22,16 @@ extension MAS {
 
         func run(installedApps: [InstalledApp]) throws {
             if installedApps.isEmpty {
-                printError("No installed apps found")
+                printError(
+                    """
+                    No installed apps found
+
+                    If this is unexpected, the following command line should fix it by
+                    (re)creating the Spotlight index (which might take some time):
+
+                    sudo mdutil -Eai on
+                    """
+                )
             } else {
                 print(AppListFormatter.format(installedApps))
             }

--- a/Tests/masTests/Commands/ListSpec.swift
+++ b/Tests/masTests/Commands/ListSpec.swift
@@ -16,7 +16,19 @@ public final class ListSpec: QuickSpec {
         describe("list command") {
             it("lists apps") {
                 expect(consequencesOf(try MAS.List.parse([]).run(installedApps: [])))
-                    == (nil, "", "Error: No installed apps found\n")
+                    == (
+                        nil,
+                        "",
+                        """
+                        Error: No installed apps found
+
+                        If this is unexpected, the following command line should fix it by
+                        (re)creating the Spotlight index (which might take some time):
+
+                        sudo mdutil -Eai on
+
+                        """
+                    )
             }
         }
     }


### PR DESCRIPTION
Warn about how to index installed apps when no apps found by `mas list`.

Resolve #809