### PR TITLE
Always install all dependencies in `Brewfile` as now only support building on macOS 13+

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,11 +1,8 @@
 brew "markdownlint-cli"
+brew "periphery"
 brew "prettier"
 brew "shellcheck"
+brew "swift-format"
 brew "swiftformat"
+brew "swiftlint"
 brew "yamllint"
-
-if OS.mac? && MacOS.version >= :ventura
-  brew "periphery"
-  brew "swift-format"
-  brew "swiftlint"
-end


### PR DESCRIPTION
Always install all dependencies in `Brewfile` as now only support building on macOS 13+.

Resolve #823