### PR TITLE
Do not delete the cache folder since it hasn't been used since 2021

### DIFF
--- a/Sources/mas/Network/NetworkManager.swift
+++ b/Sources/mas/Network/NetworkManager.swift
@@ -17,14 +17,6 @@ struct NetworkManager {
 	/// - Parameter session: A networking session.
 	init(session: NetworkSession = URLSession(configuration: .ephemeral)) {
 		self.session = session
-
-		// Older releases allowed URLSession to write a cache. We clean it up here.
-		do {
-			let url = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Caches/com.mphys.mas-cli")
-			try FileManager.default.removeItem(at: url)
-		} catch {
-			// do nothing
-		}
 	}
 
 	func loadData(from url: URL) async throws -> (Data, URLResponse) {


### PR DESCRIPTION
Do not delete the cache folder since it hasn't been used since 2021.

Resolve #833