### PR TITLE
Restrict access for imports & test classes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,8 +42,6 @@ number_separator:
   minimum_length: 6
 opening_brace:
   ignore_multiline_statement_conditions: true
-sorted_imports:
-  grouping: attributes
 type_contents_order:
   order:
   - case

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,6 @@
 // swift-tools-version:5.9
 
-import PackageDescription
+internal import PackageDescription
 
 let package = Package(
 	name: "mas",

--- a/Sources/mas/AppStore/Downloader.swift
+++ b/Sources/mas/AppStore/Downloader.swift
@@ -6,7 +6,7 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import CommerceKit
+private import CommerceKit
 
 /// Sequentially downloads apps, printing progress to the console.
 ///

--- a/Sources/mas/AppStore/ISORegion.swift
+++ b/Sources/mas/AppStore/ISORegion.swift
@@ -6,8 +6,8 @@
 // Copyright © 2024 mas-cli. All rights reserved.
 //
 
-import IsoCountryCodes
-import StoreKit
+private import IsoCountryCodes
+private import StoreKit
 
 // periphery:ignore
 protocol ISORegion {

--- a/Sources/mas/AppStore/ISStoreAccount.swift
+++ b/Sources/mas/AppStore/ISStoreAccount.swift
@@ -6,7 +6,7 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import CommerceKit
+internal import CommerceKit
 
 extension ISStoreAccount: @unchecked Sendable {
 	@MainActor // swiftlint:disable:next attributes

--- a/Sources/mas/AppStore/PurchaseDownloadObserver.swift
+++ b/Sources/mas/AppStore/PurchaseDownloadObserver.swift
@@ -6,7 +6,7 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import CommerceKit
+internal import CommerceKit
 
 private let downloadingPhaseType = 0 as Int64
 private let installingPhaseType = 1 as Int64

--- a/Sources/mas/AppStore/SSPurchase.swift
+++ b/Sources/mas/AppStore/SSPurchase.swift
@@ -6,7 +6,7 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import CommerceKit
+private import CommerceKit
 
 extension SSPurchase {
 	convenience init(appID: AppID, purchasing: Bool) async {

--- a/Sources/mas/Commands/Account.swift
+++ b/Sources/mas/Commands/Account.swift
@@ -6,8 +6,8 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
-import StoreFoundation
+internal import ArgumentParser
+private import StoreFoundation
 
 extension MAS {
 	struct Account: AsyncParsableCommand {

--- a/Sources/mas/Commands/Config.swift
+++ b/Sources/mas/Commands/Config.swift
@@ -6,8 +6,8 @@
 // Copyright © 2025 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
-import Foundation
+internal import ArgumentParser
+private import Foundation
 
 private let unknown = "unknown"
 

--- a/Sources/mas/Commands/Home.swift
+++ b/Sources/mas/Commands/Home.swift
@@ -6,8 +6,8 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
-import Foundation
+internal import ArgumentParser
+private import Foundation
 
 extension MAS {
 	/// Opens app page on MAS Preview. Uses the iTunes Lookup API:

--- a/Sources/mas/Commands/Info.swift
+++ b/Sources/mas/Commands/Info.swift
@@ -6,7 +6,7 @@
 // Copyright © 2016 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
+internal import ArgumentParser
 
 extension MAS {
 	/// Displays app details. Uses the iTunes Lookup API:

--- a/Sources/mas/Commands/Install.swift
+++ b/Sources/mas/Commands/Install.swift
@@ -6,8 +6,8 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
-import Foundation
+internal import ArgumentParser
+private import Foundation
 
 extension MAS {
 	/// Installs previously purchased apps from the Mac App Store.

--- a/Sources/mas/Commands/List.swift
+++ b/Sources/mas/Commands/List.swift
@@ -6,7 +6,7 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
+internal import ArgumentParser
 
 extension MAS {
 	/// Command which lists all installed apps.

--- a/Sources/mas/Commands/Lucky.swift
+++ b/Sources/mas/Commands/Lucky.swift
@@ -6,8 +6,8 @@
 // Copyright © 2017 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
-import Foundation
+internal import ArgumentParser
+private import Foundation
 
 extension MAS {
 	/// Command which installs the first search result.

--- a/Sources/mas/Commands/Open.swift
+++ b/Sources/mas/Commands/Open.swift
@@ -6,8 +6,8 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import AppKit
-import ArgumentParser
+private import AppKit
+internal import ArgumentParser
 
 private let masScheme = "macappstore"
 

--- a/Sources/mas/Commands/Outdated.swift
+++ b/Sources/mas/Commands/Outdated.swift
@@ -6,7 +6,7 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
+internal import ArgumentParser
 
 extension MAS {
 	/// Command which displays a list of installed apps which have available updates

--- a/Sources/mas/Commands/Purchase.swift
+++ b/Sources/mas/Commands/Purchase.swift
@@ -6,8 +6,8 @@
 // Copyright © 2017 Jakob Rieck. All rights reserved.
 //
 
-import ArgumentParser
-import Foundation
+internal import ArgumentParser
+private import Foundation
 
 extension MAS {
 	struct Purchase: AsyncParsableCommand {

--- a/Sources/mas/Commands/Region.swift
+++ b/Sources/mas/Commands/Region.swift
@@ -6,7 +6,7 @@
 // Copyright © 2024 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
+internal import ArgumentParser
 
 extension MAS {
 	/// Command which interacts with the current region for the Mac App Store.

--- a/Sources/mas/Commands/Reset.swift
+++ b/Sources/mas/Commands/Reset.swift
@@ -6,8 +6,8 @@
 // Copyright © 2016 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
-import CommerceKit
+internal import ArgumentParser
+private import CommerceKit
 
 extension MAS {
 	/// Kills several macOS processes as a means to reset the app store.

--- a/Sources/mas/Commands/Search.swift
+++ b/Sources/mas/Commands/Search.swift
@@ -6,7 +6,7 @@
 // Copyright © 2016 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
+internal import ArgumentParser
 
 extension MAS {
 	/// Search the Mac App Store. Uses the iTunes Search API:

--- a/Sources/mas/Commands/SignIn.swift
+++ b/Sources/mas/Commands/SignIn.swift
@@ -6,7 +6,7 @@
 // Copyright © 2016 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
+internal import ArgumentParser
 
 extension MAS {
 	struct SignIn: ParsableCommand {

--- a/Sources/mas/Commands/SignIn.swift
+++ b/Sources/mas/Commands/SignIn.swift
@@ -17,7 +17,6 @@ extension MAS {
 
 		@Flag(help: "Provide password via graphical dialog")
 		var dialog = false
-		// periphery:ignore
 		@Argument(help: "Apple Account")
 		var appleAccount: String
 		@Argument(help: "Password")

--- a/Sources/mas/Commands/SignOut.swift
+++ b/Sources/mas/Commands/SignOut.swift
@@ -6,8 +6,8 @@
 // Copyright © 2016 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
-import CommerceKit
+internal import ArgumentParser
+private import CommerceKit
 
 extension MAS {
 	struct SignOut: ParsableCommand {

--- a/Sources/mas/Commands/Uninstall.swift
+++ b/Sources/mas/Commands/Uninstall.swift
@@ -6,8 +6,8 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
-import ScriptingBridge
+internal import ArgumentParser
+private import ScriptingBridge
 
 extension MAS {
 	/// Command which uninstalls apps managed by the Mac App Store.

--- a/Sources/mas/Commands/Upgrade.swift
+++ b/Sources/mas/Commands/Upgrade.swift
@@ -6,8 +6,8 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
-import Foundation
+internal import ArgumentParser
+private import Foundation
 
 extension MAS {
 	/// Command which upgrades apps with new versions available in the Mac App Store.

--- a/Sources/mas/Commands/Vendor.swift
+++ b/Sources/mas/Commands/Vendor.swift
@@ -6,8 +6,8 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
-import Foundation
+internal import ArgumentParser
+private import Foundation
 
 extension MAS {
 	/// Opens vendor's app page in a browser. Uses the iTunes Lookup API:

--- a/Sources/mas/Commands/Version.swift
+++ b/Sources/mas/Commands/Version.swift
@@ -6,7 +6,7 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import ArgumentParser
+internal import ArgumentParser
 
 extension MAS {
 	/// Command which displays the version of the mas tool.

--- a/Sources/mas/Controllers/ITunesSearchAppStoreSearcher.swift
+++ b/Sources/mas/Controllers/ITunesSearchAppStoreSearcher.swift
@@ -6,7 +6,7 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Foundation
+private import Foundation
 
 /// Manages searching the MAS catalog. Uses the iTunes Search and Lookup APIs:
 /// https://performance-partners.apple.com/search-api

--- a/Sources/mas/Controllers/SpotlightInstalledApps.swift
+++ b/Sources/mas/Controllers/SpotlightInstalledApps.swift
@@ -6,7 +6,7 @@
 // Copyright © 2025 mas-cli. All rights reserved.
 //
 
-import Foundation
+private import Foundation
 
 @MainActor // swiftlint:disable:next attributes
 var installedApps: [InstalledApp] {

--- a/Sources/mas/Errors/MASError.swift
+++ b/Sources/mas/Errors/MASError.swift
@@ -6,7 +6,7 @@
 // Copyright © 2015 Andrew Naylor. All rights reserved.
 //
 
-import Foundation
+internal import Foundation
 
 enum MASError: Error, Equatable {
 	case notSupported

--- a/Sources/mas/Formatters/AppInfoFormatter.swift
+++ b/Sources/mas/Formatters/AppInfoFormatter.swift
@@ -6,7 +6,7 @@
 // Copyright © 2019 mas-cli. All rights reserved.
 //
 
-import Foundation
+private import Foundation
 
 /// Formats text output for the info command.
 enum AppInfoFormatter {

--- a/Sources/mas/Formatters/Printing.swift
+++ b/Sources/mas/Formatters/Printing.swift
@@ -6,7 +6,7 @@
 // Copyright © 2016 Andrew Naylor. All rights reserved.
 //
 
-import Foundation
+internal import Foundation
 
 // A collection of output formatting helpers
 

--- a/Sources/mas/MAS.swift
+++ b/Sources/mas/MAS.swift
@@ -6,7 +6,7 @@
 // Copyright © 2021 mas-cli. All rights reserved.
 //
 
-import ArgumentParser
+internal import ArgumentParser
 
 @main
 struct MAS: AsyncParsableCommand {

--- a/Sources/mas/Models/InstalledApp.swift
+++ b/Sources/mas/Models/InstalledApp.swift
@@ -6,8 +6,8 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Foundation
-import Version
+private import Foundation
+private import Version
 
 struct InstalledApp: Sendable {
 	let id: AppID

--- a/Sources/mas/Models/InstalledApp.swift
+++ b/Sources/mas/Models/InstalledApp.swift
@@ -12,7 +12,6 @@ private import Version
 struct InstalledApp: Sendable {
 	let id: AppID
 	let name: String
-	// periphery:ignore
 	let bundleID: String
 	let path: String
 	let version: String

--- a/Sources/mas/Network/NetworkSession.swift
+++ b/Sources/mas/Network/NetworkSession.swift
@@ -6,7 +6,7 @@
 // Copyright © 2019 mas-cli. All rights reserved.
 //
 
-import Foundation
+internal import Foundation
 
 protocol NetworkSession {
 	func data(from url: URL) async throws -> (Data, URLResponse)

--- a/Sources/mas/Network/URL.swift
+++ b/Sources/mas/Network/URL.swift
@@ -6,7 +6,7 @@
 // Copyright © 2024 mas-cli. All rights reserved.
 //
 
-import AppKit
+private import AppKit
 
 extension URL {
 	func open() async throws {

--- a/Sources/mas/Network/URLSession+NetworkSession.swift
+++ b/Sources/mas/Network/URLSession+NetworkSession.swift
@@ -6,6 +6,6 @@
 // Copyright © 2019 mas-cli. All rights reserved.
 //
 
-import Foundation
+private import Foundation
 
 extension URLSession: NetworkSession {}

--- a/Sources/mas/Utilities/Finder.swift
+++ b/Sources/mas/Utilities/Finder.swift
@@ -6,17 +6,18 @@
 // Copyright © 2024 mas-cli. All rights reserved.
 //
 
+// periphery:ignore:all
 // swift-format-ignore-file
 // swiftlint:disable:next blanket_disable_command
 // swiftlint:disable attributes discouraged_none_name file_length file_types_order identifier_name
 // swiftlint:disable:next blanket_disable_command
-// swiftlint:disable implicitly_unwrapped_optional legacy_objc_type line_length missing_docs one_declaration_per_file
-import AppKit
-import ScriptingBridge
+// swiftlint:disable implicitly_unwrapped_optional legacy_objc_type line_length one_declaration_per_file
+internal import AppKit
+internal import ScriptingBridge
 
 // MARK: FinderEdfm
 @objc
-public enum FinderEdfm: AEKeyword {
+enum FinderEdfm: AEKeyword {
 	case macOSFormat = 0x6466_6866 // 'dfhf'
 	case macOSExtendedFormat = 0x6466_682b // 'dfh+'
 	case ufsFormat = 0x6466_7566 // 'dfuf'
@@ -43,7 +44,7 @@ public enum FinderEdfm: AEKeyword {
 
 // MARK: FinderIpnl
 @objc
-public enum FinderIpnl: AEKeyword {
+enum FinderIpnl: AEKeyword {
 	case generalInformationPanel = 0x6770_6e6c // 'gpnl'
 	case sharingPanel = 0x7370_6e6c // 'spnl'
 	case memoryPanel = 0x6d70_6e6c // 'mpnl'
@@ -61,7 +62,7 @@ public enum FinderIpnl: AEKeyword {
 
 // MARK: FinderPple
 @objc
-public enum FinderPple: AEKeyword {
+enum FinderPple: AEKeyword {
 	case generalPreferencesPanel = 0x7067_6e70 // 'pgnp'
 	case labelPreferencesPanel = 0x706c_6270 // 'plbp'
 	case sidebarPreferencesPanel = 0x7073_6964 // 'psid'
@@ -70,7 +71,7 @@ public enum FinderPple: AEKeyword {
 
 // MARK: FinderPriv
 @objc
-public enum FinderPriv: AEKeyword {
+enum FinderPriv: AEKeyword {
 	case readOnly = 0x7265_6164 // 'read'
 	case readWrite = 0x7264_7772 // 'rdwr'
 	case writeOnly = 0x7772_6974 // 'writ'
@@ -79,7 +80,7 @@ public enum FinderPriv: AEKeyword {
 
 // MARK: FinderEcvw
 @objc
-public enum FinderEcvw: AEKeyword {
+enum FinderEcvw: AEKeyword {
 	case iconView = 0x6963_6e76 // 'icnv'
 	case listView = 0x6c73_7677 // 'lsvw'
 	case columnView = 0x636c_7677 // 'clvw'
@@ -89,7 +90,7 @@ public enum FinderEcvw: AEKeyword {
 
 // MARK: FinderEarr
 @objc
-public enum FinderEarr: AEKeyword {
+enum FinderEarr: AEKeyword {
 	case notArranged = 0x6e61_7272 // 'narr'
 	case snapToGrid = 0x6772_6461 // 'grda'
 	case arrangedByName = 0x6e61_6d61 // 'nama'
@@ -102,21 +103,21 @@ public enum FinderEarr: AEKeyword {
 
 // MARK: FinderEpos
 @objc
-public enum FinderEpos: AEKeyword {
+enum FinderEpos: AEKeyword {
 	case right = 0x6c72_6774 // 'lrgt'
 	case bottom = 0x6c62_6f74 // 'lbot'
 }
 
 // MARK: FinderSodr
 @objc
-public enum FinderSodr: AEKeyword {
+enum FinderSodr: AEKeyword {
 	case normal = 0x736e_726d // 'snrm'
 	case reversed = 0x7372_7673 // 'srvs'
 }
 
 // MARK: FinderElsv
 @objc
-public enum FinderElsv: AEKeyword {
+enum FinderElsv: AEKeyword {
 	case nameColumn = 0x656c_736e // 'elsn'
 	case modificationDateColumn = 0x656c_736d // 'elsm'
 	case creationDateColumn = 0x656c_7363 // 'elsc'
@@ -129,18 +130,18 @@ public enum FinderElsv: AEKeyword {
 
 // MARK: FinderLvic
 @objc
-public enum FinderLvic: AEKeyword {
+enum FinderLvic: AEKeyword {
 	case smallIcon = 0x736d_6963 // 'smic'
 	case largeIcon = 0x6c67_6963 // 'lgic'
 }
 
 @objc
-public protocol SBObjectProtocol: NSObjectProtocol {
+protocol SBObjectProtocol: NSObjectProtocol {
 	func get() -> Any!
 }
 
 @objc
-public protocol SBApplicationProtocol: SBObjectProtocol {
+protocol SBApplicationProtocol: SBObjectProtocol {
 	var delegate: SBApplicationDelegate! { get set }
 	var isRunning: Bool { get }
 
@@ -149,7 +150,7 @@ public protocol SBApplicationProtocol: SBObjectProtocol {
 
 // MARK: FinderGenericMethods
 @objc
-public protocol FinderGenericMethods {
+protocol FinderGenericMethods {
 	@objc optional func openUsing(_ using_: SBObject!, withProperties: [AnyHashable: Any]!) // Open the specified object(s)
 	@objc optional func printWithProperties(_ withProperties: [AnyHashable: Any]!) // Print the specified object(s)
 	@objc optional func activate() // Activate the specified window (or the Finder)
@@ -171,7 +172,7 @@ public protocol FinderGenericMethods {
 
 // MARK: FinderApplication
 @objc
-public protocol FinderApplication: SBApplicationProtocol {
+protocol FinderApplication: SBApplicationProtocol {
 	@objc optional var clipboard: SBObject { get } // (NOT AVAILABLE YET) the Finder’s clipboard window (copy)
 	@objc optional var name: String { get } // the Finder’s name (copy)
 	@objc optional var visible: Bool { get } // Is the Finder’s layer visible?
@@ -223,7 +224,7 @@ extension SBApplication: FinderApplication {}
 
 // MARK: FinderItem
 @objc
-public protocol FinderItem: SBObjectProtocol, FinderGenericMethods {
+protocol FinderItem: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var name: String { get } // the name of the item (copy)
 	@objc optional var displayedName: String { get } // the user-visible name of the item (copy)
 	@objc optional var nameExtension: String { get } // the name extension of the item (such as “txt”) (copy)
@@ -276,7 +277,7 @@ extension SBObject: FinderItem {}
 
 // MARK: FinderContainer
 @objc
-public protocol FinderContainer: FinderItem {
+protocol FinderContainer: FinderItem {
 	@objc optional var entireContents: SBObject { get } // the entire contents of the container, including the contents of its children (copy)
 	@objc optional var expandable: Bool { get } // (NOT AVAILABLE YET) Is the container capable of being expanded as an outline?
 	@objc optional var expanded: Bool { get } // (NOT AVAILABLE YET) Is the container opened as an outline? (can only be set for containers viewed as lists)
@@ -302,13 +303,13 @@ extension SBObject: FinderContainer {}
 
 // MARK: FinderComputerObject
 @objc
-public protocol FinderComputerObject: FinderItem {}
+protocol FinderComputerObject: FinderItem {}
 
 extension SBObject: FinderComputerObject {}
 
 // MARK: FinderDisk
 @objc
-public protocol FinderDisk: FinderContainer {
+protocol FinderDisk: FinderContainer {
 	@objc optional var capacity: Int64 { get } // the total number of bytes (free or used) on the disk
 	@objc optional var freeSpace: Int64 { get } // the number of free bytes left on the disk
 	@objc optional var ejectable: Bool { get } // Can the media be ejected (floppies, CDs, and so on)?
@@ -338,7 +339,7 @@ extension SBObject: FinderDisk {}
 
 // MARK: FinderFolder
 @objc
-public protocol FinderFolder: FinderContainer {
+protocol FinderFolder: FinderContainer {
 	@objc optional func items() -> SBElementArray
 	@objc optional func containers() -> SBElementArray
 	@objc optional func folders() -> SBElementArray
@@ -355,7 +356,7 @@ extension SBObject: FinderFolder {}
 
 // MARK: FinderDesktopObject
 @objc
-public protocol FinderDesktopObject: FinderContainer {
+protocol FinderDesktopObject: FinderContainer {
 	@objc optional func items() -> SBElementArray
 	@objc optional func containers() -> SBElementArray
 	@objc optional func disks() -> SBElementArray
@@ -373,7 +374,7 @@ extension SBObject: FinderDesktopObject {}
 
 // MARK: FinderTrashObject
 @objc
-public protocol FinderTrashObject: FinderContainer {
+protocol FinderTrashObject: FinderContainer {
 	@objc optional var warnsBeforeEmptying: Bool { get } // Display a dialog when emptying the trash?
 
 	@objc optional func setWarnsBeforeEmptying(_ warnsBeforeEmptying: Bool) // Display a dialog when emptying the trash?
@@ -394,7 +395,7 @@ extension SBObject: FinderTrashObject {}
 
 // MARK: FinderFile
 @objc
-public protocol FinderFile: FinderItem {
+protocol FinderFile: FinderItem {
 	@objc optional var fileType: NSNumber { get } // the OSType identifying the type of data contained in the item (copy)
 	@objc optional var creatorType: NSNumber { get } // the OSType identifying the application that created the item (copy)
 	@objc optional var stationery: Bool { get } // Is the file a stationery pad?
@@ -410,7 +411,7 @@ extension SBObject: FinderFile {}
 
 // MARK: FinderAliasFile
 @objc
-public protocol FinderAliasFile: FinderFile {
+protocol FinderAliasFile: FinderFile {
 	@objc optional var originalItem: SBObject { get } // the original item pointed to by the alias (copy)
 
 	@objc optional func setOriginalItem(_ originalItem: SBObject!) // the original item pointed to by the alias
@@ -420,7 +421,7 @@ extension SBObject: FinderAliasFile {}
 
 // MARK: FinderApplicationFile
 @objc
-public protocol FinderApplicationFile: FinderFile {
+protocol FinderApplicationFile: FinderFile {
 	@objc optional var suggestedSize: Int { get } // (AVAILABLE IN 10.1 TO 10.4) the memory size with which the developer recommends the application be launched
 	@objc optional var minimumSize: Int { get } // (AVAILABLE IN 10.1 TO 10.4) the smallest memory size with which the application can be launched
 	@objc optional var preferredSize: Int { get } // (AVAILABLE IN 10.1 TO 10.4) the memory size with which the application will be launched
@@ -439,13 +440,13 @@ extension SBObject: FinderApplicationFile {}
 
 // MARK: FinderDocumentFile
 @objc
-public protocol FinderDocumentFile: FinderFile {}
+protocol FinderDocumentFile: FinderFile {}
 
 extension SBObject: FinderDocumentFile {}
 
 // MARK: FinderInternetLocationFile
 @objc
-public protocol FinderInternetLocationFile: FinderFile {
+protocol FinderInternetLocationFile: FinderFile {
 	@objc optional var location: String { get } // the internet location (copy)
 }
 
@@ -453,7 +454,7 @@ extension SBObject: FinderInternetLocationFile {}
 
 // MARK: FinderClipping
 @objc
-public protocol FinderClipping: FinderFile {
+protocol FinderClipping: FinderFile {
 	@objc optional var clippingWindow: SBObject { get } // (NOT AVAILABLE YET) the clipping window for this clipping (copy)
 }
 
@@ -461,13 +462,13 @@ extension SBObject: FinderClipping {}
 
 // MARK: FinderPackage
 @objc
-public protocol FinderPackage: FinderItem {}
+protocol FinderPackage: FinderItem {}
 
 extension SBObject: FinderPackage {}
 
 // MARK: FinderWindow
 @objc
-public protocol FinderWindow: SBObjectProtocol, FinderGenericMethods {
+protocol FinderWindow: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var position: NSPoint { get } // the upper left position of the window
 	@objc optional var bounds: NSRect { get } // the boundary rectangle for the window
 	@objc optional var titled: Bool { get } // Does the window have a title bar?
@@ -497,7 +498,7 @@ extension SBObject: FinderWindow {}
 
 // MARK: FinderFinderWindow
 @objc
-public protocol FinderFinderWindow: FinderWindow {
+protocol FinderFinderWindow: FinderWindow {
 	@objc optional var target: SBObject { get } // the container at which this file viewer is targeted (copy)
 	@objc optional var currentView: FinderEcvw { get } // the current view for the container window
 	@objc optional var iconViewOptions: FinderIconViewOptions { get } // the icon view options for the container window (copy)
@@ -518,13 +519,13 @@ extension SBObject: FinderFinderWindow {}
 
 // MARK: FinderDesktopWindow
 @objc
-public protocol FinderDesktopWindow: FinderFinderWindow {}
+protocol FinderDesktopWindow: FinderFinderWindow {}
 
 extension SBObject: FinderDesktopWindow {}
 
 // MARK: FinderInformationWindow
 @objc
-public protocol FinderInformationWindow: FinderWindow {
+protocol FinderInformationWindow: FinderWindow {
 	@objc optional var item: SBObject { get } // the item from which this window was opened (copy)
 	@objc optional var currentPanel: FinderIpnl { get } // the current panel in the information window
 
@@ -535,7 +536,7 @@ extension SBObject: FinderInformationWindow {}
 
 // MARK: FinderPreferencesWindow
 @objc
-public protocol FinderPreferencesWindow: FinderWindow {
+protocol FinderPreferencesWindow: FinderWindow {
 	@objc optional var currentPanel: FinderPple { get } // The current panel in the Finder preferences window
 
 	@objc optional func setCurrentPanel(_ currentPanel: FinderPple) // The current panel in the Finder preferences window
@@ -545,13 +546,13 @@ extension SBObject: FinderPreferencesWindow {}
 
 // MARK: FinderClippingWindow
 @objc
-public protocol FinderClippingWindow: FinderWindow {}
+protocol FinderClippingWindow: FinderWindow {}
 
 extension SBObject: FinderClippingWindow {}
 
 // MARK: FinderProcess
 @objc
-public protocol FinderProcess: SBObjectProtocol, FinderGenericMethods {
+protocol FinderProcess: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var name: String { get } // the name of the process (copy)
 	@objc optional var visible: Bool { get } // Is the process' layer visible?
 	@objc optional var frontmost: Bool { get } // Is the process the frontmost process?
@@ -572,7 +573,7 @@ extension SBObject: FinderProcess {}
 
 // MARK: FinderApplicationProcess
 @objc
-public protocol FinderApplicationProcess: FinderProcess {
+protocol FinderApplicationProcess: FinderProcess {
 	@objc optional var applicationFile: FinderApplicationFile { get } // the application file from which this process was launched (copy)
 }
 
@@ -580,7 +581,7 @@ extension SBObject: FinderApplicationProcess {}
 
 // MARK: FinderDeskAccessoryProcess
 @objc
-public protocol FinderDeskAccessoryProcess: FinderProcess {
+protocol FinderDeskAccessoryProcess: FinderProcess {
 	@objc optional var deskAccessoryFile: SBObject { get } // the desk accessory file from which this process was launched (copy)
 }
 
@@ -588,7 +589,7 @@ extension SBObject: FinderDeskAccessoryProcess {}
 
 // MARK: FinderPreferences
 @objc
-public protocol FinderPreferences: SBObjectProtocol, FinderGenericMethods {
+protocol FinderPreferences: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var window: FinderPreferencesWindow { get } // the window that would open if Finder preferences was opened (copy)
 	@objc optional var iconViewOptions: FinderIconViewOptions { get } // the default icon view options (copy)
 	@objc optional var listViewOptions: FinderListViewOptions { get } // the default list view options (copy)
@@ -622,7 +623,7 @@ extension SBObject: FinderPreferences {}
 
 // MARK: FinderLabel
 @objc
-public protocol FinderLabel: SBObjectProtocol, FinderGenericMethods {
+protocol FinderLabel: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var name: String { get } // the name associated with the label (copy)
 	@objc optional var index: Int { get } // the index in the front-to-back ordering within its container
 	@objc optional var color: NSColor { get } // the color associated with the label (copy)
@@ -636,7 +637,7 @@ extension SBObject: FinderLabel {}
 
 // MARK: FinderIconFamily
 @objc
-public protocol FinderIconFamily: SBObjectProtocol, FinderGenericMethods {
+protocol FinderIconFamily: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var largeMonochromeIconAndMask: Any { get } // the large black-and-white icon and the mask for large icons (copy)
 	@objc optional var large8BitMask: Any { get } // the large 8-bit mask for large 32-bit icons (copy)
 	@objc optional var large32BitIcon: Any { get } // the large 32-bit color icon (copy)
@@ -653,7 +654,7 @@ extension SBObject: FinderIconFamily {}
 
 // MARK: FinderIconViewOptions
 @objc
-public protocol FinderIconViewOptions: SBObjectProtocol, FinderGenericMethods {
+protocol FinderIconViewOptions: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var arrangement: FinderEarr { get } // the property by which to keep icons arranged
 	@objc optional var iconSize: Int { get } // the size of icons displayed in the icon view
 	@objc optional var showsItemInfo: Bool { get } // additional info about an item displayed in icon view
@@ -677,7 +678,7 @@ extension SBObject: FinderIconViewOptions {}
 
 // MARK: FinderColumnViewOptions
 @objc
-public protocol FinderColumnViewOptions: SBObjectProtocol, FinderGenericMethods {
+protocol FinderColumnViewOptions: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var textSize: Int { get } // the size of the text displayed in the column view
 	@objc optional var showsIcon: Bool { get } // displays an icon next to the label in column view
 	@objc optional var showsIconPreview: Bool { get } // displays a preview of the item in column view
@@ -695,7 +696,7 @@ extension SBObject: FinderColumnViewOptions {}
 
 // MARK: FinderListViewOptions
 @objc
-public protocol FinderListViewOptions: SBObjectProtocol, FinderGenericMethods {
+protocol FinderListViewOptions: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var calculatesFolderSizes: Bool { get } // Are folder sizes calculated and displayed in the window?
 	@objc optional var showsIconPreview: Bool { get } // displays a preview of the item in list view
 	@objc optional var iconSize: FinderLvic { get } // the size of icons displayed in the list view
@@ -717,7 +718,7 @@ extension SBObject: FinderListViewOptions {}
 
 // MARK: FinderColumn
 @objc
-public protocol FinderColumn: SBObjectProtocol, FinderGenericMethods {
+protocol FinderColumn: SBObjectProtocol, FinderGenericMethods {
 	@objc optional var index: Int { get } // the index in the front-to-back ordering within its container
 	@objc optional var name: FinderElsv { get } // the column name
 	@objc optional var sortDirection: FinderSodr { get } // The direction in which the window is sorted
@@ -736,6 +737,6 @@ extension SBObject: FinderColumn {}
 
 // MARK: FinderAliasList
 @objc
-public protocol FinderAliasList: SBObjectProtocol, FinderGenericMethods {}
+protocol FinderAliasList: SBObjectProtocol, FinderGenericMethods {}
 
 extension SBObject: FinderAliasList {}

--- a/Sources/mas/Utilities/ProcessInfo.swift
+++ b/Sources/mas/Utilities/ProcessInfo.swift
@@ -6,7 +6,7 @@
 // Copyright © 2024 mas-cli. All rights reserved.
 //
 
-import Foundation
+internal import Foundation
 
 extension ProcessInfo {
 	var sudoUsername: String? {

--- a/Tests/masTests/Commands/AccountSpec.swift
+++ b/Tests/masTests/Commands/AccountSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class AccountSpec: AsyncSpec {
-	override public static func spec() {
+final class AccountSpec: AsyncSpec {
+	override static func spec() {
 		describe("account command") {
 			it("displays not supported warning") {
 				await expecta(await consequencesOf(try await MAS.Account.parse([]).run()))

--- a/Tests/masTests/Commands/HomeSpec.swift
+++ b/Tests/masTests/Commands/HomeSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class HomeSpec: AsyncSpec {
-	override public static func spec() {
+final class HomeSpec: AsyncSpec {
+	override static func spec() {
 		describe("home command") {
 			it("can't find app with unknown ID") {
 				await expecta(

--- a/Tests/masTests/Commands/InfoSpec.swift
+++ b/Tests/masTests/Commands/InfoSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class InfoSpec: AsyncSpec {
-	override public static func spec() {
+final class InfoSpec: AsyncSpec {
+	override static func spec() {
 		describe("Info command") {
 			it("can't find app with unknown ID") {
 				await expecta(

--- a/Tests/masTests/Commands/InstallSpec.swift
+++ b/Tests/masTests/Commands/InstallSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class InstallSpec: AsyncSpec {
-	override public static func spec() {
+final class InstallSpec: AsyncSpec {
+	override static func spec() {
 		xdescribe("install command") {
 			it("installs apps") {
 				await expecta(

--- a/Tests/masTests/Commands/ListSpec.swift
+++ b/Tests/masTests/Commands/ListSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class ListSpec: QuickSpec {
-	override public static func spec() {
+final class ListSpec: QuickSpec {
+	override static func spec() {
 		describe("list command") {
 			it("lists apps") {
 				expect(consequencesOf(try MAS.List.parse([]).run(installedApps: [])))

--- a/Tests/masTests/Commands/LuckySpec.swift
+++ b/Tests/masTests/Commands/LuckySpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class LuckySpec: AsyncSpec {
-	override public static func spec() {
+final class LuckySpec: AsyncSpec {
+	override static func spec() {
 		let searcher =
 			ITunesSearchAppStoreSearcher(networkSession: MockNetworkSession(responseResource: "search/slack.json"))
 

--- a/Tests/masTests/Commands/OpenSpec.swift
+++ b/Tests/masTests/Commands/OpenSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2019 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class OpenSpec: AsyncSpec {
-	override public static func spec() {
+final class OpenSpec: AsyncSpec {
+	override static func spec() {
 		describe("open command") {
 			it("can't find app with unknown ID") {
 				await expecta(

--- a/Tests/masTests/Commands/OutdatedSpec.swift
+++ b/Tests/masTests/Commands/OutdatedSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class OutdatedSpec: AsyncSpec {
-	override public static func spec() {
+final class OutdatedSpec: AsyncSpec {
+	override static func spec() {
 		describe("outdated command") {
 			it("displays apps with pending updates") {
 				let mockSearchResult =

--- a/Tests/masTests/Commands/PurchaseSpec.swift
+++ b/Tests/masTests/Commands/PurchaseSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2020 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class PurchaseSpec: AsyncSpec {
-	override public static func spec() {
+final class PurchaseSpec: AsyncSpec {
+	override static func spec() {
 		xdescribe("purchase command") {
 			it("purchases apps") {
 				await expecta(

--- a/Tests/masTests/Commands/SearchSpec.swift
+++ b/Tests/masTests/Commands/SearchSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class SearchSpec: AsyncSpec {
-	override public static func spec() {
+final class SearchSpec: AsyncSpec {
+	override static func spec() {
 		describe("search command") {
 			it("can find slack") {
 				let mockResult = SearchResult(

--- a/Tests/masTests/Commands/SignInSpec.swift
+++ b/Tests/masTests/Commands/SignInSpec.swift
@@ -6,14 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-/// Deprecated test.
-public final class SignInSpec: QuickSpec {
-	override public static func spec() {
+final class SignInSpec: QuickSpec {
+	override static func spec() {
 		describe("signin command") {
 			it("signs in") {
 				expect(consequencesOf(try MAS.SignIn.parse(["", ""]).run()))

--- a/Tests/masTests/Commands/SignOutSpec.swift
+++ b/Tests/masTests/Commands/SignOutSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class SignOutSpec: QuickSpec {
-	override public static func spec() {
+final class SignOutSpec: QuickSpec {
+	override static func spec() {
 		describe("signout command") {
 			it("signs out") {
 				expect(consequencesOf(try MAS.SignOut.parse([]).run()))

--- a/Tests/masTests/Commands/UninstallSpec.swift
+++ b/Tests/masTests/Commands/UninstallSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class UninstallSpec: QuickSpec {
-	override public static func spec() {
+final class UninstallSpec: QuickSpec {
+	override static func spec() {
 		let appID = 12345 as AppID
 		let app = InstalledApp(
 			id: appID,

--- a/Tests/masTests/Commands/UpgradeSpec.swift
+++ b/Tests/masTests/Commands/UpgradeSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class UpgradeSpec: AsyncSpec {
-	override public static func spec() {
+final class UpgradeSpec: AsyncSpec {
+	override static func spec() {
 		describe("upgrade command") {
 			it("finds no upgrades") {
 				await expecta(

--- a/Tests/masTests/Commands/VendorSpec.swift
+++ b/Tests/masTests/Commands/VendorSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2019 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class VendorSpec: AsyncSpec {
-	override public static func spec() {
+final class VendorSpec: AsyncSpec {
+	override static func spec() {
 		describe("vendor command") {
 			it("can't find app with unknown ID") {
 				await expecta(

--- a/Tests/masTests/Commands/VersionSpec.swift
+++ b/Tests/masTests/Commands/VersionSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class VersionSpec: QuickSpec {
-	override public static func spec() {
+final class VersionSpec: QuickSpec {
+	override static func spec() {
 		describe("version command") {
 			it("displays the current version") {
 				expect(consequencesOf(try MAS.Version.parse([]).run()))

--- a/Tests/masTests/Controllers/ITunesSearchAppStoreSearcherSpec.swift
+++ b/Tests/masTests/Controllers/ITunesSearchAppStoreSearcherSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2019 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class ITunesSearchAppStoreSearcherSpec: AsyncSpec {
-	override public static func spec() {
+final class ITunesSearchAppStoreSearcherSpec: AsyncSpec {
+	override static func spec() {
 		describe("store") {
 			it("can search for slack") {
 				let searcher =

--- a/Tests/masTests/Controllers/MockAppStoreSearcher.swift
+++ b/Tests/masTests/Controllers/MockAppStoreSearcher.swift
@@ -6,7 +6,7 @@
 // Copyright © 2019 mas-cli. All rights reserved.
 //
 
-@testable import mas
+@testable internal import mas
 
 struct MockAppStoreSearcher: AppStoreSearcher {
 	let apps: [AppID: SearchResult]

--- a/Tests/masTests/Formatters/AppListFormatterSpec.swift
+++ b/Tests/masTests/Formatters/AppListFormatterSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2020 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class AppListFormatterSpec: QuickSpec {
-	override public static func spec() {
+final class AppListFormatterSpec: QuickSpec {
+	override static func spec() {
 		// static func reference
 		let format = AppListFormatter.format(_:)
 

--- a/Tests/masTests/Formatters/SearchResultFormatterSpec.swift
+++ b/Tests/masTests/Formatters/SearchResultFormatterSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2019 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class SearchResultFormatterSpec: QuickSpec {
-	override public static func spec() {
+final class SearchResultFormatterSpec: QuickSpec {
+	override static func spec() {
 		// static func reference
 		let format = SearchResultFormatter.format(_:includePrice:)
 

--- a/Tests/masTests/Models/InstalledAppSpec.swift
+++ b/Tests/masTests/Models/InstalledAppSpec.swift
@@ -6,13 +6,13 @@
 // Copyright © 2021 mas-cli. All rights reserved.
 //
 
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class InstalledAppSpec: QuickSpec {
-	override public static func spec() {
+final class InstalledAppSpec: QuickSpec {
+	override static func spec() {
 		let app = InstalledApp(
 			id: 111,
 			name: "App",

--- a/Tests/masTests/Models/SearchResultListSpec.swift
+++ b/Tests/masTests/Models/SearchResultListSpec.swift
@@ -7,13 +7,13 @@
 //
 
 import Foundation
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class SearchResultListSpec: QuickSpec {
-	override public static func spec() {
+final class SearchResultListSpec: QuickSpec {
+	override static func spec() {
 		describe("search result list") {
 			it("can parse bbedit") {
 				expect(

--- a/Tests/masTests/Models/SearchResultSpec.swift
+++ b/Tests/masTests/Models/SearchResultSpec.swift
@@ -7,13 +7,13 @@
 //
 
 import Foundation
-import Nimble
+private import Nimble
 import Quick
 
-@testable import mas
+@testable private import mas
 
-public final class SearchResultSpec: QuickSpec {
-	override public static func spec() {
+final class SearchResultSpec: QuickSpec {
+	override static func spec() {
 		describe("search result") {
 			it("can parse things") {
 				expect(

--- a/Tests/masTests/Network/MockNetworkSession.swift
+++ b/Tests/masTests/Network/MockNetworkSession.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@testable import mas
+@testable private import mas
 
 /// Mock NetworkSession for testing with a saved response payload file.
 struct MockNetworkSession: NetworkSession {

--- a/Tests/masTests/Utilities/Consequences.swift
+++ b/Tests/masTests/Utilities/Consequences.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@testable import mas
+@testable internal import mas
 
 func consequencesOf(
 	streamEncoding: String.Encoding = .utf8,

--- a/Tests/masTests/Utilities/Consequences.swift
+++ b/Tests/masTests/Utilities/Consequences.swift
@@ -26,7 +26,6 @@ func consequencesOf(
 	return (consequences.error, consequences.stdout, consequences.stderr)
 }
 
-// periphery:ignore
 func consequencesOf<T>(
 	streamEncoding: String.Encoding = .utf8,
 	_ expression: @autoclosure @escaping () throws -> T

--- a/script/lint
+++ b/script/lint
@@ -60,7 +60,7 @@ git diff --check
 ((exit_code |= ${?}))
 
 printf -- $'--> 🌀 Periphery\n'
-script -q /dev/null periphery scan --strict --quiet --relative-results --disable-update-check |
+script -q /dev/null periphery scan --strict --quiet --relative-results --disable-update-check --external-test-case-classes AsyncSpec --external-test-case-classes QuickSpec |
  (grep -vxE '(?:\x1b\[0;1;32m|\^D\x08{2})\* (?:\x1b\[0;0m\x1b\[0;1m)?No unused code detected\.(?:\x1b\[0;0m)?\r' || true)
 ((exit_code |= ${?}))
 


### PR DESCRIPTION
Restrict access for imports.

Make all `AsyncSpec` & `QuickSpec` subclasses internal.

Remove unnecessary `periphery:ignore` comments.

Resolve #854