### PR TITLE
No longer include iOS or iPadOS apps in `search` results

### DIFF
--- a/Sources/mas/Controllers/ITunesSearchAppStoreSearcher.swift
+++ b/Sources/mas/Controllers/ITunesSearchAppStoreSearcher.swift
@@ -5,7 +5,6 @@
 // Copyright © 2018 mas-cli. All rights reserved.
 //
 
-private import Collections
 private import Foundation
 
 /// Manages searching the MAS catalog.
@@ -14,13 +13,6 @@ private import Foundation
 ///
 /// https://performance-partners.apple.com/search-api
 struct ITunesSearchAppStoreSearcher: AppStoreSearcher {
-	enum Entity: String {
-		case desktopSoftware
-		case macSoftware
-		case iPadSoftware
-		case iPhoneSoftware = "software"
-	}
-
 	private let networkSession: NetworkSession
 
 	/// Designated initializer.
@@ -53,22 +45,7 @@ struct ITunesSearchAppStoreSearcher: AppStoreSearcher {
 	/// - Returns: An `Array` of `SearchResult`s matching `searchTerm`.
 	/// - Throws: An `Error` if any problem occurs.
 	func search(for searchTerm: String, inRegion region: ISORegion?) async throws -> [SearchResult] {
-		// Search for apps for compatible platforms, in order of preference.
-		// Macs with Apple Silicon can run iPad & iPhone apps.
-		#if arch(arm64)
-		let entities = [Entity.desktopSoftware, .iPadSoftware, .iPhoneSoftware]
-		#else
-		let entities = [Entity.desktopSoftware]
-		#endif
-
-		var appSet = OrderedSet<SearchResult>()
-		for entity in entities {
-			appSet.formUnion(
-				try await getSearchResults(from: try searchURL(for: searchTerm, inRegion: region, ofEntity: entity))
-			)
-		}
-
-		return Array(appSet)
+		try await getSearchResults(from: try searchURL(for: searchTerm, inRegion: region))
 	}
 
 	/// Builds the lookup URL for an app.
@@ -76,15 +53,10 @@ struct ITunesSearchAppStoreSearcher: AppStoreSearcher {
 	/// - Parameters:
 	///   - appID: App ID.
 	///   - region: The `ISORegion` of the storefront in which to lookup apps.
-	///   - entity: OS platform of apps for which to search.
 	/// - Returns: URL for the lookup service.
 	/// - Throws: An `MASError.urlParsing` if `appID` can't be encoded.
-	private func lookupURL(
-		forAppID appID: AppID,
-		inRegion region: ISORegion?,
-		ofEntity entity: Entity = .desktopSoftware
-	) throws -> URL {
-		try url("lookup", URLQueryItem(name: "id", value: String(appID)), inRegion: region, ofEntity: entity)
+	private func lookupURL(forAppID appID: AppID, inRegion region: ISORegion?) throws -> URL {
+		try url("lookup", URLQueryItem(name: "id", value: String(appID)), inRegion: region)
 	}
 
 	/// Builds the search URL for an app.
@@ -92,23 +64,13 @@ struct ITunesSearchAppStoreSearcher: AppStoreSearcher {
 	/// - Parameters:
 	///   - searchTerm: term for which to search in MAS.
 	///   - region: The `ISORegion` of the storefront in which to search for apps.
-	///   - entity: OS platform of apps for which to search.
 	/// - Returns: URL for the search service.
 	/// - Throws: An `MASError.urlParsing` if `searchTerm` can't be encoded.
-	private func searchURL(
-		for searchTerm: String,
-		inRegion region: ISORegion?,
-		ofEntity entity: Entity = .desktopSoftware
-	) throws -> URL {
-		try url("search", URLQueryItem(name: "term", value: searchTerm), inRegion: region, ofEntity: entity)
+	private func searchURL(for searchTerm: String, inRegion region: ISORegion?) throws -> URL {
+		try url("search", URLQueryItem(name: "term", value: searchTerm), inRegion: region)
 	}
 
-	private func url(
-		_ action: String,
-		_ queryItem: URLQueryItem,
-		inRegion region: ISORegion?,
-		ofEntity entity: Entity = .desktopSoftware
-	) throws -> URL {
+	private func url(_ action: String, _ queryItem: URLQueryItem, inRegion region: ISORegion?) throws -> URL {
 		let urlBase = "https://itunes.apple.com/\(action)"
 		guard var urlComponents = URLComponents(string: urlBase) else {
 			throw MASError.urlParsing(urlBase)
@@ -116,7 +78,7 @@ struct ITunesSearchAppStoreSearcher: AppStoreSearcher {
 
 		var queryItems = [
 			URLQueryItem(name: "media", value: "software"),
-			URLQueryItem(name: "entity", value: entity.rawValue),
+			URLQueryItem(name: "entity", value: "desktopSoftware"),
 		]
 
 		if let region {


### PR DESCRIPTION
No longer include iOS or iPadOS apps in `search` results.

Resolve #721