### PR TITLE
Refactor `Reset`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -47,6 +47,8 @@ function_body_length:
   warning: 75
 indentation_width:
   include_multiline_strings: false
+line_length:
+  ignores_multiline_strings: true
 number_separator:
   minimum_length: 6
 opening_brace:

--- a/Sources/mas/Commands/Reset.swift
+++ b/Sources/mas/Commands/Reset.swift
@@ -5,6 +5,7 @@
 // Copyright © 2016 mas-cli. All rights reserved.
 //
 
+private import AppKit
 internal import ArgumentParser
 private import CommerceKit
 
@@ -32,37 +33,56 @@ extension MAS {
 		/// As `storeagent` no longer exists, terminates all processes known to be
 		/// associated with the Mac App Store.
 		func run(printer: Printer) {
-			let killall = Process()
-			killall.launchPath = "/usr/bin/killall"
-			killall.arguments = [
-				"ContextStoreAgent",
-				"Dock",
-				"SetStoreUpdateService",
-				"appstoreagent",
-				"appstorecomponentsd",
-				"storeaccountd",
-				"storeassetd",
-				"storedownloadd",
-				"storeinstalld",
-				"storekitagent",
-				"storelegacy",
-				"storeuid",
-			]
-			let stderr = Pipe()
-			killall.standardError = stderr
-			killall.standardOutput = Pipe()
+			for bundleID in ["com.apple.dock", "com.apple.storeuid"] {
+				for app in NSRunningApplication.runningApplications(withBundleIdentifier: bundleID) where !app.terminate() {
+					printer.warning("Failed to terminate app with bundle ID:", bundleID)
+					if !app.forceTerminate() {
+						printer.error("Failed to force terminate app with bundle ID:", bundleID)
+					}
+				}
+			}
 
-			killall.launch()
-			killall.waitUntilExit()
-			if killall.terminationStatus != 0 {
-				let output = stderr.fileHandleForReading.readDataToEndOfFile()
-				printer.error(
-					"killall failed with exit status ",
-					killall.terminationStatus,
-					":\n",
-					String(data: output, encoding: .utf8) ?? "Error info not available",
-					separator: ""
-				)
+			let executablePathSet = Set([
+				"/System/Library/Frameworks/StoreKit.framework/Support/storekitagent",
+				"/System/Library/PrivateFrameworks/AppStoreComponents.framework/Support/appstorecomponentsd",
+				"/System/Library/PrivateFrameworks/AppStoreDaemon.framework/Support/appstoreagent",
+				"""
+				/System/Library/PrivateFrameworks/CascadeSets.framework/Versions/A/XPCServices/SetStoreUpdateService.xpc/Contents/MacOS/SetStoreUpdateService
+				""",
+				"/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Resources/storeaccountd",
+				"/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Resources/storeassetd",
+				"/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Resources/storedownloadd",
+				"/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Resources/storeinstalld",
+				"/System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Resources/storelegacy",
+			])
+
+			var processListMIB = [CTL_KERN, KERN_PROC, KERN_PROC_ALL]
+			var length = 0
+			guard sysctl(&processListMIB, u_int(processListMIB.count), nil, &length, nil, 0) == 0 else {
+				printer.error("Failed to get process list length")
+				return
+			}
+
+			var kinfoProcs = [kinfo_proc](repeating: kinfo_proc(), count: length / MemoryLayout<kinfo_proc>.stride)
+			guard sysctl(&processListMIB, u_int(processListMIB.count), &kinfoProcs, &length, nil, 0) == 0 else {
+				printer.error("Failed to get process list")
+				return
+			}
+
+			var executablePathBuffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+			for pid in kinfoProcs.map(\.kp_proc.p_pid) {
+				guard
+					proc_pidpath(pid, &executablePathBuffer, UInt32(executablePathBuffer.count)) > 0,
+					let executablePath = String(cString: executablePathBuffer, encoding: .utf8),
+					executablePathSet.contains(executablePath)
+				else {
+					continue
+				}
+
+				let exitStatus = kill(pid, SIGTERM)
+				if exitStatus != 0 {
+					printer.error("Failed to terminate", executablePath, "getting exit status", exitStatus, "for pid", pid)
+				}
 			}
 
 			let folder = CKDownloadDirectory(nil)


### PR DESCRIPTION
Refactor `Reset` to terminate processes using C APIs, instead of running the `killall` shell command via a Swift `Process`.

Terminate processes by full executable path instead of by executable name.

Terminate `com.apple.dock` & `com.apple.storeuid` as applications instead of as processes.

No longer terminate `ContextStoreAgent`.

Resolve #667