### PR TITLE
Rename commands & properties to align with App Store terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ it, running mas might report errors similar to:
 
 To get Swift 5 support on macOS versions older than 10.14.4 (Mojave), you can:
 
-- Upgrade to macOS 10.14.4 (Mojave) or newer.
+- Update to macOS 10.14.4 (Mojave) or newer.
 - Install the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/en-us/106446).
 - Install Xcode 10.2 or newer to `/Applications/Xcode.app`.
 
@@ -129,7 +129,7 @@ $ mas list
 
 #### `mas outdated`
 
-`mas outdated` outputs all applications installed from the Mac App Store on your Mac that have pending upgrades.
+`mas outdated` outputs all applications installed from the Mac App Store on your Mac that have pending updates.
 
 ```console
 $ mas outdated
@@ -137,24 +137,24 @@ $ mas outdated
 640199958 Developer (10.6.5 -> 10.6.6)
 ```
 
-Run [`mas upgrade`](#mas-upgrade) to install pending upgrades.
+Run [`mas update`](#mas-update) to install pending updates.
 
 ### ⬇️ Installing Apps
 
 All the commands in this section require you to be logged into an Apple Account in the Mac App Store.
 
 > Depending on your Apple Account settings, you might need to re-authenticate yourself in the Mac App Store to perform a
-> purchase, install, lucky, or upgrade, even if you are already signed in to an Apple Account in the Mac App Store.
+> get, install, lucky, or update, even if you are already signed in to an Apple Account in the Mac App Store.
 
-#### `mas purchase`
+#### `mas get`
 
-`mas purchase <app-id>…` installs free applications that you haven't yet gotten/"purchased" from the Mac App Store.
+`mas get <app-id>…` installs free applications that you haven't yet gotten/"purchased" from the Mac App Store.
 
-> `purchase` is currently a misnomer, because it currently can only "purchase" free apps. To purchase apps that cost
-> money, please purchase them directly in the Mac App Store.
+> The `purchase` alias is currently a misnomer, because it currently can only "purchase" free apps. To purchase apps
+> that cost money, please purchase them directly in the Mac App Store.
 
 ```console
-$ mas purchase 497799835
+$ mas get 497799835
 ==> Downloading Xcode
 ==> Installed Xcode
 ```
@@ -185,17 +185,17 @@ $ mas lucky Xcode
 
 All the commands in this section require you to be logged into an Apple Account in the Mac App Store.
 
-> mas only installs/upgrades applications from the Mac App Store.
+> mas only installs/updates applications from the Mac App Store.
 >
 > Use [`softwareupdate(8)`](https://www.unix.com/man-page/osx/8/softwareupdate) to install system updates (e.g., Xcode
 > Command Line Tools, Safari, etc.)
 
-#### `mas upgrade`
+#### `mas update`
 
-`mas upgrade` upgrades outdated apps installed from the Mac App Store. Without any arguments, it upgrades all such apps.
+`mas update` updates outdated apps installed from the Mac App Store. Without any arguments, it updates all such apps.
 
 ```console
-$ mas upgrade
+$ mas update
 Upgrading 2 outdated applications:
 Xcode (15.4) -> (16.0)
 Developer (10.6.5) -> (10.6.6)
@@ -205,10 +205,10 @@ Developer (10.6.5) -> (10.6.6)
 ==> Installed Developer
 ```
 
-Upgrades can be performed selectively by providing app IDs to `mas upgrade`.
+Updates can be performed selectively by providing app IDs to `mas update`.
 
 ```console
-$ mas upgrade 715768417
+$ mas update 715768417
 Upgrading 1 outdated application:
 Xcode (15.4) -> (16.0)
 ==> Downloading Xcode
@@ -292,7 +292,7 @@ brew install reattach-to-user-namespace
 reattach-to-user-namespace mas install
 ```
 
-### 📭 `mas list`, `mas outdated`, `mas uninstall`, or `mas upgrade` does not detect installed apps
+### 📭 `mas list`, `mas outdated`, `mas uninstall`, or `mas update` does not detect installed apps
 
 mas 2.0.0+ sources data for installed Mac App Store apps from macOS's Spotlight metadata store.
 
@@ -328,13 +328,13 @@ sudo mdutil -Eai on
 
 ## 🚫 When something doesn't work
 
-If you see the following error, it's probably because you haven't yet "purchased" the app through the Mac App Store. See
-[#46](https://github.com/mas-cli/mas/issues/46#issuecomment-248581233).
+If you see the following error, it's probably because you haven't yet gotten/"purchased" the app through the Mac App
+Store. See [#46](https://github.com/mas-cli/mas/issues/46#issuecomment-248581233).
 
 > This redownload is not available for this Apple Account either because it was bought by a different user or the item
 > was refunded or canceled.
 
-If mas doesn't work for you as expected (e.g., you can't install/upgrade apps), run `mas reset`, then try again. If the
+If mas doesn't work for you as expected (e.g., you can't install/update apps), run `mas reset`, then try again. If the
 issue persists, please [file a bug](https://github.com/mas-cli/mas/issues/new). All feedback is much appreciated! ✨
 
 ## 🏗 Build from source

--- a/Sources/mas/AppStore/Downloader.swift
+++ b/Sources/mas/AppStore/Downloader.swift
@@ -14,13 +14,13 @@ struct Downloader {
 
 	func downloadApp(
 		withADAMID adamID: ADAMID,
-		purchasing: Bool = false,
+		getting: Bool = false,
 		forceDownload: Bool = false, // swiftlint:disable:this function_default_parameter_at_end
 		installedApps: [InstalledApp]
 	) async throws {
 		if !forceDownload, let installedApp = installedApps.first(where: { $0.adamID == adamID }) {
 			printer.warning(
-				purchasing ? "Already purchased: " : "Already installed: ",
+				getting ? "Already gotten: " : "Already installed: ",
 				installedApp.name,
 				" (",
 				adamID,
@@ -30,17 +30,17 @@ struct Downloader {
 			return
 		}
 
-		try await downloadApp(withADAMID: adamID, purchasing: purchasing)
+		try await downloadApp(withADAMID: adamID, getting: getting)
 	}
 
 	func downloadApp(
 		withADAMID adamID: ADAMID,
-		purchasing: Bool = false,
+		getting: Bool = false,
 		shouldCancel: @Sendable @escaping (SSDownload, Bool) -> Bool = { _, _ in false },
 		withAttemptCount attemptCount: UInt32 = 3
 	) async throws {
 		do {
-			let purchase = await SSPurchase(adamID: adamID, purchasing: purchasing)
+			let purchase = await SSPurchase(adamID: adamID, getting: getting)
 			_ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
 				CKPurchaseController.shared().perform(purchase, withOptions: 0) { _, _, error, response in
 					if let error {
@@ -83,7 +83,7 @@ struct Downloader {
 			)
 			try await downloadApp(
 				withADAMID: adamID,
-				purchasing: purchasing,
+				getting: getting,
 				shouldCancel: shouldCancel,
 				withAttemptCount: attemptCount
 			)

--- a/Sources/mas/AppStore/SSPurchase.swift
+++ b/Sources/mas/AppStore/SSPurchase.swift
@@ -8,16 +8,16 @@
 private import StoreFoundation
 
 extension SSPurchase {
-	convenience init(adamID: ADAMID, purchasing: Bool) async {
+	convenience init(adamID: ADAMID, getting: Bool) async {
 		self.init(
 			buyParameters: """
 				productType=C&price=0&pg=default&appExtVrsId=0&pricingParameters=\
-				\(purchasing ? "STDQ&macappinstalledconfirmed=1" : "STDRDL")&salableAdamId=\(adamID)
+				\(getting ? "STDQ&macappinstalledconfirmed=1" : "STDRDL")&salableAdamId=\(adamID)
 				"""
 		)
 
 		// Possibly unnecessary…
-		isRedownload = !purchasing
+		isRedownload = !getting
 
 		itemIdentifier = adamID
 

--- a/Sources/mas/Commands/Get.swift
+++ b/Sources/mas/Commands/Get.swift
@@ -1,5 +1,5 @@
 //
-// Purchase.swift
+// Get.swift
 // mas
 //
 // Copyright © 2025 mas-cli. All rights reserved.
@@ -8,10 +8,11 @@
 internal import ArgumentParser
 
 extension MAS {
-	/// "Purchases" & installs free apps from the Mac App Store.
-	struct Purchase: AsyncParsableCommand {
+	/// Gets & installs free apps from the Mac App Store.
+	struct Get: AsyncParsableCommand {
 		static let configuration = CommandConfiguration(
-			abstract: "\"Purchase\" & install free apps from the Mac App Store"
+			abstract: "Get & install free apps from the Mac App Store",
+			aliases: ["purchase"]
 		)
 
 		@OptionGroup
@@ -28,7 +29,7 @@ extension MAS {
 					do {
 						try await downloader.downloadApp(
 							withADAMID: try await appID.adamID(searcher: searcher),
-							purchasing: true,
+							getting: true,
 							installedApps: installedApps
 						)
 					} catch {

--- a/Sources/mas/Commands/Home.swift
+++ b/Sources/mas/Commands/Home.swift
@@ -32,7 +32,7 @@ extension MAS {
 
 		private func run(printer: Printer, searcher: some AppStoreSearcher) async {
 			await requiredAppIDsOptionGroup.forEachAppID(printer: printer) { appID in
-				let urlString = try await searcher.lookup(appID: appID).appStoreURL
+				let urlString = try await searcher.lookup(appID: appID).appStorePageURL
 				guard let url = URL(string: urlString) else {
 					throw MASError.urlParsing(urlString)
 				}

--- a/Sources/mas/Commands/Info.swift
+++ b/Sources/mas/Commands/Info.swift
@@ -38,11 +38,11 @@ extension MAS {
 					"",
 					"""
 					\(result.name) \(result.version) [\(result.formattedPrice)]
-					By: \(result.vendorName)
+					By: \(result.sellerName)
 					Released: \(result.releaseDate.humanReadableDate)
 					Minimum OS: \(result.minimumOSVersion)
 					Size: \(result.fileSizeBytes.humanReadableSize)
-					From: \(result.appStoreURL)
+					From: \(result.appStorePageURL)
 					""",
 					separator: spacing
 				)

--- a/Sources/mas/Commands/Install.swift
+++ b/Sources/mas/Commands/Install.swift
@@ -8,10 +8,10 @@
 internal import ArgumentParser
 
 extension MAS {
-	/// Installs previously purchased apps from the Mac App Store.
+	/// Installs previously gotten apps from the Mac App Store.
 	struct Install: AsyncParsableCommand {
 		static let configuration = CommandConfiguration(
-			abstract: "Install previously purchased apps from the Mac App Store"
+			abstract: "Install previously gotten apps from the Mac App Store"
 		)
 
 		@OptionGroup

--- a/Sources/mas/Commands/Lucky.swift
+++ b/Sources/mas/Commands/Lucky.swift
@@ -9,7 +9,7 @@ internal import ArgumentParser
 
 extension MAS {
 	/// Installs the first app returned from searching the Mac App Store (app must
-	/// have been previously purchased).
+	/// have been previously gotten).
 	///
 	/// Uses the iTunes Search API:
 	///
@@ -17,7 +17,7 @@ extension MAS {
 	struct Lucky: AsyncParsableCommand {
 		static let configuration = CommandConfiguration(
 			abstract: "Install the first app returned from searching the Mac App Store",
-			discussion: "App will install only if it has already been purchased"
+			discussion: "App will install only if it has already been gotten"
 		)
 
 		@OptionGroup

--- a/Sources/mas/Commands/MAS.swift
+++ b/Sources/mas/Commands/MAS.swift
@@ -14,6 +14,7 @@ struct MAS: AsyncParsableCommand {
 		subcommands: [
 			Account.self,
 			Config.self,
+			Get.self,
 			Home.self,
 			Info.self,
 			Install.self,
@@ -21,15 +22,14 @@ struct MAS: AsyncParsableCommand {
 			Lucky.self,
 			Open.self,
 			Outdated.self,
-			Purchase.self,
 			Region.self,
 			Reset.self,
 			Search.self,
+			Seller.self,
 			SignIn.self,
 			SignOut.self,
 			Uninstall.self,
-			Upgrade.self,
-			Vendor.self,
+			Update.self,
 			Version.self,
 		]
 	)

--- a/Sources/mas/Commands/Open.swift
+++ b/Sources/mas/Commands/Open.swift
@@ -45,7 +45,7 @@ extension MAS {
 				forURLString: try await searcher.lookup(
 					appID: AppID(from: appIDString, forceBundleID: forceBundleIDOptionGroup.forceBundleID)
 				)
-				.appStoreURL
+				.appStorePageURL
 			)
 		}
 	}

--- a/Sources/mas/Commands/Seller.swift
+++ b/Sources/mas/Commands/Seller.swift
@@ -1,5 +1,5 @@
 //
-// Vendor.swift
+// Seller.swift
 // mas
 //
 // Copyright © 2018 mas-cli. All rights reserved.
@@ -9,14 +9,15 @@ internal import ArgumentParser
 private import Foundation
 
 extension MAS {
-	/// Opens apps' vendor pages in the default web browser.
+	/// Opens apps' seller pages in the default web browser.
 	///
 	/// Uses the iTunes Lookup API:
 	///
 	/// https://performance-partners.apple.com/search-api
-	struct Vendor: AsyncParsableCommand {
+	struct Seller: AsyncParsableCommand {
 		static let configuration = CommandConfiguration(
-			abstract: "Open apps' vendor pages in the default web browser"
+			abstract: "Open apps' seller pages in the default web browser",
+			aliases: ["vendor"]
 		)
 
 		@OptionGroup
@@ -32,8 +33,8 @@ extension MAS {
 
 		private func run(printer: Printer, searcher: some AppStoreSearcher) async {
 			await requiredAppIDsOptionGroup.forEachAppID(printer: printer) { appID in
-				guard let urlString = try await searcher.lookup(appID: appID).vendorURL else {
-					throw MASError.noVendorWebsite(forAppID: appID)
+				guard let urlString = try await searcher.lookup(appID: appID).sellerURL else {
+					throw MASError.noSellerURL(forAppID: appID)
 				}
 				guard let url = URL(string: urlString) else {
 					throw MASError.urlParsing(urlString)

--- a/Sources/mas/Commands/Update.swift
+++ b/Sources/mas/Commands/Update.swift
@@ -1,5 +1,5 @@
 //
-// Upgrade.swift
+// Update.swift
 // mas
 //
 // Copyright © 2015 mas-cli. All rights reserved.
@@ -9,10 +9,11 @@ internal import ArgumentParser
 private import StoreFoundation
 
 extension MAS {
-	/// Upgrades outdated apps installed from the Mac App Store.
-	struct Upgrade: AsyncParsableCommand {
+	/// Updates outdated apps installed from the Mac App Store.
+	struct Update: AsyncParsableCommand {
 		static let configuration = CommandConfiguration(
-			abstract: "Upgrade outdated apps installed from the Mac App Store"
+			abstract: "Update outdated apps installed from the Mac App Store",
+			aliases: ["upgrade"]
 		)
 
 		@OptionGroup

--- a/Sources/mas/Errors/MASError.swift
+++ b/Sources/mas/Errors/MASError.swift
@@ -12,7 +12,7 @@ enum MASError: Error {
 	case jsonParsing(input: String? = nil)
 	case noDownloads
 	case noSearchResultsFound(for: String)
-	case noVendorWebsite(forAppID: AppID)
+	case noSellerURL(forAppID: AppID)
 	case notSupported
 	case runtimeError(String)
 	case unknownAppID(AppID)
@@ -30,8 +30,8 @@ extension MASError: CustomStringConvertible {
 			"No downloads began"
 		case let .noSearchResultsFound(searchTerm):
 			"No apps found in the Mac App Store for search term: \(searchTerm)"
-		case let .noVendorWebsite(appID):
-			"No vendor website available for \(appID)"
+		case let .noSellerURL(appID):
+			"No seller website available for \(appID)"
 		case .notSupported:
 			"""
 			This command is not supported on this macOS version due to changes in macOS

--- a/Sources/mas/Models/SearchResult.swift
+++ b/Sources/mas/Models/SearchResult.swift
@@ -7,7 +7,7 @@
 
 struct SearchResult: Equatable {
 	let adamID: ADAMID
-	let appStoreURL: String
+	let appStorePageURL: String
 	// periphery:ignore
 	let bundleID: String
 	let fileSizeBytes: String
@@ -15,34 +15,34 @@ struct SearchResult: Equatable {
 	let minimumOSVersion: String
 	let name: String
 	let releaseDate: String
-	let vendorName: String
-	let vendorURL: String?
+	let sellerName: String
+	let sellerURL: String?
 	let version: String
 
 	// periphery:ignore
 	init(
 		adamID: ADAMID = 0,
-		appStoreURL: String = "",
+		appStorePageURL: String = "",
 		bundleID: String = "",
 		fileSizeBytes: String = "0",
 		formattedPrice: String? = "0",
 		minimumOSVersion: String = "",
 		name: String = "",
 		releaseDate: String = "",
-		vendorName: String = "",
-		vendorURL: String? = nil,
+		sellerName: String = "",
+		sellerURL: String? = nil,
 		version: String = ""
 	) {
 		self.adamID = adamID
-		self.appStoreURL = appStoreURL
+		self.appStorePageURL = appStorePageURL
 		self.bundleID = bundleID
 		self.fileSizeBytes = fileSizeBytes
 		self.formattedPrice = formattedPrice ?? "?"
 		self.minimumOSVersion = minimumOSVersion
 		self.name = name
 		self.releaseDate = releaseDate
-		self.vendorName = vendorName
-		self.vendorURL = vendorURL
+		self.sellerName = sellerName
+		self.sellerURL = sellerURL
 		self.version = version
 	}
 }
@@ -50,15 +50,15 @@ struct SearchResult: Equatable {
 extension SearchResult: Decodable {
 	enum CodingKeys: String, CodingKey {
 		case adamID = "trackId"
-		case appStoreURL = "trackViewUrl"
+		case appStorePageURL = "trackViewUrl"
 		case bundleID = "bundleId"
 		case fileSizeBytes
 		case formattedPrice
 		case minimumOSVersion = "minimumOsVersion"
 		case name = "trackName"
 		case releaseDate = "currentVersionReleaseDate"
-		case vendorName = "sellerName"
-		case vendorURL = "sellerUrl"
+		case sellerName
+		case sellerURL = "sellerUrl"
 		case version
 	}
 }

--- a/Tests/MASTests/Commands/MASTests+Get.swift
+++ b/Tests/MASTests/Commands/MASTests+Get.swift
@@ -1,5 +1,5 @@
 //
-// MASTests+Purchase.swift
+// MASTests+Get.swift
 // mas
 //
 // Copyright © 2020 mas-cli. All rights reserved.
@@ -11,9 +11,9 @@ internal import Testing
 
 extension MASTests {
 	@Test(.disabled())
-	static func purchasesApps() async {
+	static func getsApps() async {
 		let actual = await consequencesOf(
-			try await MAS.Purchase.parse(["999"]).run(installedApps: [], searcher: MockAppStoreSearcher())
+			try await MAS.Get.parse(["999"]).run(installedApps: [], searcher: MockAppStoreSearcher())
 		)
 		let expected = Consequences()
 		#expect(actual == expected)

--- a/Tests/MASTests/Commands/MASTests+Info.swift
+++ b/Tests/MASTests/Commands/MASTests+Info.swift
@@ -24,13 +24,13 @@ extension MASTests {
 				searcher: MockAppStoreSearcher(
 					SearchResult(
 						adamID: 1,
-						appStoreURL: "https://awesome.app",
+						appStorePageURL: "https://awesome.app",
 						fileSizeBytes: "1000000",
 						formattedPrice: "$2.00",
 						minimumOSVersion: "10.14",
 						name: "Awesome App",
 						releaseDate: "2019-01-07T18:53:13Z",
-						vendorName: "Awesome Dev",
+						sellerName: "Awesome Dev",
 						version: "1.0"
 					)
 				)

--- a/Tests/MASTests/Commands/MASTests+Outdated.swift
+++ b/Tests/MASTests/Commands/MASTests+Outdated.swift
@@ -15,14 +15,14 @@ extension MASTests {
 		let result =
 			SearchResult(
 				adamID: 490_461_369,
-				appStoreURL: "https://apps.apple.com/us/app/bandwidth/id490461369?mt=12&uo=4",
+				appStorePageURL: "https://apps.apple.com/us/app/bandwidth/id490461369?mt=12&uo=4",
 				bundleID: "au.haroldchu.mac.Bandwidth",
 				fileSizeBytes: "998130",
 				minimumOSVersion: "10.13",
 				name: "Bandwidth+",
 				releaseDate: "2024-09-02T00:27:00Z",
-				vendorName: "Harold Chu",
-				vendorURL: "https://example.com",
+				sellerName: "Harold Chu",
+				sellerURL: "https://example.com",
 				version: "1.28"
 			)
 		let actual = await consequencesOf(

--- a/Tests/MASTests/Commands/MASTests+Seller.swift
+++ b/Tests/MASTests/Commands/MASTests+Seller.swift
@@ -1,5 +1,5 @@
 //
-// MASTests+Vendor.swift
+// MASTests+Seller.swift
 // mas
 //
 // Copyright © 2019 mas-cli. All rights reserved.
@@ -11,8 +11,8 @@ internal import Testing
 
 extension MASTests {
 	@Test
-	static func cannotFindVendorOfUnknownAppID() async {
-		let actual = await consequencesOf(try await MAS.Vendor.parse(["999"]).run(searcher: MockAppStoreSearcher()))
+	static func cannotFindSellerURLForUnknownAppID() async {
+		let actual = await consequencesOf(try await MAS.Seller.parse(["999"]).run(searcher: MockAppStoreSearcher()))
 		let expected = Consequences(ExitCode(1), "", "Error: No apps found in the Mac App Store for ADAM ID 999\n")
 		#expect(actual == expected)
 	}

--- a/Tests/MASTests/Commands/MASTests+Update.swift
+++ b/Tests/MASTests/Commands/MASTests+Update.swift
@@ -1,5 +1,5 @@
 //
-// MASTests+Upgrade.swift
+// MASTests+Update.swift
 // mas
 //
 // Copyright © 2018 mas-cli. All rights reserved.
@@ -11,8 +11,8 @@ internal import Testing
 
 extension MASTests {
 	@Test(.disabled())
-	static func findsNoUpgrades() async {
-		let actual = await consequencesOf(try await MAS.Upgrade.parse([]).run(installedApps: []))
+	static func findsNoUpdates() async {
+		let actual = await consequencesOf(try await MAS.Update.parse([]).run(installedApps: []))
 		let expected = Consequences()
 		#expect(actual == expected)
 	}

--- a/Tests/MASTests/Controllers/MASTests+ITunesSearchAppStoreSearcher.swift
+++ b/Tests/MASTests/Controllers/MASTests+ITunesSearchAppStoreSearcher.swift
@@ -32,11 +32,11 @@ extension MASTests {
 		}
 
 		#expect(
-			result.adamID == adamID
-			&& result.vendorName == "Slack Technologies, Inc." // swiftformat:disable indent
-			&& result.vendorURL == "https://slack.com"
+			result.adamID == adamID // swiftformat:disable indent
+			&& result.appStorePageURL == "https://itunes.apple.com/us/app/slack/id803453959?mt=12&uo=4"
 			&& result.name == "Slack"
-			&& result.appStoreURL == "https://itunes.apple.com/us/app/slack/id803453959?mt=12&uo=4"
+			&& result.sellerName == "Slack Technologies, Inc."
+			&& result.sellerURL == "https://slack.com"
 			&& result.version == "3.3.3"
 		) // swiftformat:enable indent
 	}

--- a/contrib/completion/mas.fish
+++ b/contrib/completion/mas.fish
@@ -27,25 +27,28 @@ complete -c mas -n "__fish_seen_subcommand_from help" -xa "account"
 complete -c mas -n "__fish_use_subcommand" -f -a config -d "Output mas config & related system info"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "config"
 complete -c mas -n "__fish_seen_subcommand_from config" -l markdown -d "Output as Markdown"
+### get
+complete -c mas -n "__fish_use_subcommand" -f -a get -d "Get & install free apps from the Mac App Store"
+complete -c mas -n "__fish_seen_subcommand_from help" -xa "get"
 ### help
 complete -c mas -n "__fish_use_subcommand" -f -a help -d "Output general or command-specific help"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "help"
 ### home
 complete -c mas -n "__fish_use_subcommand" -f -a home -d "Open Mac App Store app pages in the default web browser"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "home"
-complete -c mas -n "__fish_seen_subcommand_from home info install open purchase vendor" -xa "(__fish_mas_list_available)"
+complete -c mas -n "__fish_seen_subcommand_from get home info install open seller" -xa "(__fish_mas_list_available)"
 ### info
 complete -c mas -n "__fish_use_subcommand" -f -a info -d "Output app information from the Mac App Store"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "info"
 ### install
-complete -c mas -n "__fish_use_subcommand" -f -a install -d "Install previously purchased apps from the Mac App Store"
+complete -c mas -n "__fish_use_subcommand" -f -a install -d "Install previously gotten apps from the Mac App Store"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "install"
 complete -c mas -n "__fish_seen_subcommand_from install lucky" -l force -d "Force reinstall"
 ### list
 complete -c mas -n "__fish_use_subcommand" -f -a list -d "List all apps installed from the Mac App Store"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "list"
 ### lucky
-complete -c mas -n "__fish_use_subcommand" -f -a lucky -d "Install the first app returned from searching the Mac App Store (app must have been previously purchased)"
+complete -c mas -n "__fish_use_subcommand" -f -a lucky -d "Install the first app returned from searching the Mac App Store (app must have been previously gotten)"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "lucky"
 ### open
 complete -c mas -n "__fish_use_subcommand" -f -a open -d "Open app page in 'App Store.app'"
@@ -54,9 +57,6 @@ complete -c mas -n "__fish_seen_subcommand_from help" -xa "open"
 complete -c mas -n "__fish_use_subcommand" -f -a outdated -d "List pending app updates from the Mac App Store"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "outdated"
 complete -c mas -n "__fish_seen_subcommand_from outdated" -l verbose -d "Output warnings about app IDs unknown to the Mac App Store"
-### purchase
-complete -c mas -n "__fish_use_subcommand" -f -a purchase -d "\"Purchase\" & install free apps from the Mac App Store"
-complete -c mas -n "__fish_seen_subcommand_from help" -xa "purchase"
 ### region
 complete -c mas -n "__fish_use_subcommand" -f -a region -d "Output the region of the Mac App Store"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "region"
@@ -68,6 +68,9 @@ complete -c mas -n "__fish_seen_subcommand_from reset" -l debug -d "Output debug
 complete -c mas -n "__fish_use_subcommand" -f -a search -d "Search for apps in the Mac App Store"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "search"
 complete -c mas -n "__fish_seen_subcommand_from search" -l price -d "Output the price of each app"
+### seller
+complete -c mas -n "__fish_use_subcommand" -f -a seller -d "Open apps' seller pages in the default web browser"
+complete -c mas -n "__fish_seen_subcommand_from help" -xa "seller"
 ### signin
 complete -c mas -n "__fish_use_subcommand" -f -a signin -d "Sign in to an Apple Account in the Mac App Store"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "signin"
@@ -80,13 +83,10 @@ complete -c mas -n "__fish_use_subcommand" -f -a uninstall -d "Uninstall apps in
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "uninstall"
 complete -c mas -n "__fish_seen_subcommand_from uninstall" -l dry-run -d "Perform dry run"
 complete -c mas -n "__fish_seen_subcommand_from uninstall" -x -a "(__fish_mas_list_installed)"
-### upgrade
-complete -c mas -n "__fish_use_subcommand" -f -a upgrade -d "Upgrade outdated apps installed from the Mac App Store"
-complete -c mas -n "__fish_seen_subcommand_from help" -xa "upgrade"
-complete -c mas -n "__fish_seen_subcommand_from upgrade" -x -a "(__fish_mas_outdated_installed)"
-### vendor
-complete -c mas -n "__fish_use_subcommand" -f -a vendor -d "Open apps' vendor pages in the default web browser"
-complete -c mas -n "__fish_seen_subcommand_from help" -xa "vendor"
+### update
+complete -c mas -n "__fish_use_subcommand" -f -a update -d "Update outdated apps installed from the Mac App Store"
+complete -c mas -n "__fish_seen_subcommand_from help" -xa "update"
+complete -c mas -n "__fish_seen_subcommand_from update" -x -a "(__fish_mas_outdated_installed)"
 ### version
 complete -c mas -n "__fish_use_subcommand" -f -a version -d "Output version number"
 complete -c mas -n "__fish_seen_subcommand_from help" -xa "version"


### PR DESCRIPTION
Rename commands & properties to align with App Store terminology.

Resolve #1023