### PR TITLE
Remove unnecessary `Hashable` conformance from `AppID`

### DIFF
--- a/Sources/mas/Models/AppID.swift
+++ b/Sources/mas/Models/AppID.swift
@@ -5,7 +5,7 @@
 // Copyright © 2024 mas-cli. All rights reserved.
 //
 
-enum AppID: CustomStringConvertible, Hashable {
+enum AppID: CustomStringConvertible {
 	case adamID(ADAMID)
 	case bundleID(String)
 


### PR DESCRIPTION
Remove unnecessary `Hashable` conformance from `AppID`.

Resolve #1033