### PR TITLE
Use `let` instead of literal computer `var`

### DIFF
--- a/Sources/mas/Controllers/SpotlightInstalledApps.swift
+++ b/Sources/mas/Controllers/SpotlightInstalledApps.swift
@@ -73,4 +73,4 @@ var installedApps: [InstalledApp] {
 	}
 }
 
-private var applicationsFolder: String { "/Applications" }
+private let applicationsFolder = "/Applications"


### PR DESCRIPTION
Use `let` instead of literal computer `var`.

Resolve #1037