### PR TITLE
Improve root permission error message in `uninstall`

### DIFF
--- a/Sources/mas/Commands/Uninstall.swift
+++ b/Sources/mas/Commands/Uninstall.swift
@@ -34,7 +34,7 @@ extension MAS {
 
 		func run(installedApps: [InstalledApp]) throws {
 			guard NSUserName() == "root" else {
-				throw MASError.runtimeError("Apps installed from the Mac App Store require root permission to remove")
+				throw MASError.runtimeError("Apps installed from the Mac App Store require root permission to uninstall")
 			}
 
 			let uninstallingAppPaths = uninstallingAppPaths(fromInstalledApps: installedApps)


### PR DESCRIPTION
Improve root permission error message in `uninstall`.

Resolve #1048