### PR TITLE
Create a hard link instead of a symlink when creating pkg installers

### DIFF
--- a/Scripts/package
+++ b/Scripts/package
@@ -20,7 +20,7 @@ mas_executable="${destination_dir}/mas"
 version="$(Scripts/version)"
 
 mkdir -p "${destination_dir}"
-ln -sF "${${mas_executable:h}//[^\/]##/..}${${$(swift build -c release --show-bin-path "${@:2}"):a}##~0}/mas" "${mas_executable}"
+ln -f "$(swift build -c release --show-bin-path "${@:2}")/mas" "${mas_executable}"
 
 pkgbuild\
  --identifier io.github.mas-cli.mas\


### PR DESCRIPTION
Create a hard link instead of a symlink when creating pkg installers.

Resolve #1050