### PR TITLE
Cleanup workaround for installd/PackageKit access restriction introduced in macOS 26.1, 15.7.2 & 14.8.2

### DIFF
--- a/Sources/mas/AppStore/DownloadQueueObserver.swift
+++ b/Sources/mas/AppStore/DownloadQueueObserver.swift
@@ -321,6 +321,7 @@ final class DownloadQueueObserver: CKDownloadQueueObserver {
 			try run(asEffectiveUID: 0, andEffectiveGID: 0) {
 				try fileManager.createDirectory(at: receiptURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 				try fileManager.copyItem(at: receiptHardLinkURL, to: receiptURL)
+				try fileManager.setAttributes([.ownerAccountID: 0, .groupOwnerAccountID: 0], ofItemAtPath: receiptURL.path)
 			}
 		} catch {
 			throw MASError.runtimeError(


### PR DESCRIPTION
Cleanup workaround for installd/PackageKit access restriction introduced in macOS 26.1, 15.7.2 & 14.8.2.

Change owner of receipt to root:wheel when installing/updating an app.

Resolve #1029