### PR TITLE
Include app identifying info in warnings & errors as suitable & as easily accomplished

### DIFF
--- a/Sources/mas/AppStore/Downloader.swift
+++ b/Sources/mas/AppStore/Downloader.swift
@@ -43,7 +43,7 @@ func downloadApp(
 				return
 			}
 			guard response?.downloads?.isEmpty == false else {
-				continuation.resume(throwing: MASError.runtimeError("No downloads began"))
+				continuation.resume(throwing: MASError.runtimeError("No downloads initiated for ADAMID \(adamID)"))
 				return
 			}
 

--- a/Sources/mas/Commands/Seller.swift
+++ b/Sources/mas/Commands/Seller.swift
@@ -35,7 +35,7 @@ extension MAS {
 			await run(
 				sellerURLs: catalogApps.compactMap { catalogApp in
 					guard let sellerURL = catalogApp.sellerURL else {
-						printer.error("No seller website available for", catalogApp.adamID)
+						printer.error("No seller website available for ADAMID", catalogApp.adamID)
 						return nil
 					}
 

--- a/Sources/mas/Controllers/ITunesSearchAppCatalog.swift
+++ b/Sources/mas/Controllers/ITunesSearchAppCatalog.swift
@@ -111,7 +111,8 @@ struct ITunesSearchAppCatalog: AppCatalog {
 			return try JSONDecoder().decode(CatalogAppResults.self, from: data).results
 		} catch {
 			throw MASError.runtimeError(
-				"Unable to parse input as JSON\(String(data: data, encoding: .utf8).map { ":\n\($0)" } ?? "")"
+				"Unable to parse response from \(url) as JSON",
+				error: String(data: data, encoding: .utf8) ?? ""
 			)
 		}
 	}

--- a/Sources/mas/Errors/MASError.swift
+++ b/Sources/mas/Errors/MASError.swift
@@ -13,6 +13,10 @@ enum MASError: Error {
 	case runtimeError(String, error: (any Error)? = nil)
 	case unknownAppID(AppID)
 	case urlParsing(String)
+
+	static func runtimeError(_ message: String, error: String) -> Self {
+		runtimeError(message, error: runtimeError(error))
+	}
 }
 
 extension MASError: CustomStringConvertible {


### PR DESCRIPTION
Include app identifying info in warnings & errors as suitable & as easily accomplished.

Improve errors & warning.

Throw some errors instead of printing.

Simplify `runtimeError` creation when for an `error: MASError.runtimeError`.

Merge guards.

#1079