### PR TITLE
Improve mas version parsability

### DIFF
--- a/Scripts/version
+++ b/Scripts/version
@@ -19,6 +19,6 @@ if [[ "${branch}" = HEAD ]]; then
 fi
 
 printf $'%s%s%s\n'\
- "${branch:+"${branch}-"}"\
  "${"$(git describe --tags 2>/dev/null)"#v}"\
+ "${branch:+"-${branch}"}"\
  "${"$(git diff-index HEAD --;git ls-files --exclude-standard --others)":+"${MAS_DIRTY_INDICATOR-+}"}"


### PR DESCRIPTION
Improve mas version parsability.

Append branch name to git tag description instead of prepending it in version names.

Resolve #1082