### PR TITLE
Fix installer output parsing deadlock

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,7 +51,7 @@ file_length:
   ignore_comment_only_lines: true
   warning: 500
 file_name:
-  excluded: [Group.swift, User.swift]
+  excluded: [Group.swift, Process.swift, User.swift]
 file_types_order:
   order:
   - main_type

--- a/Sources/mas/Utilities/Pipe.swift
+++ b/Sources/mas/Utilities/Pipe.swift
@@ -1,0 +1,14 @@
+//
+// Pipe.swift
+// mas
+//
+// Copyright © 2025 mas-cli. All rights reserved.
+//
+
+internal import Foundation
+
+extension Pipe {
+	func readToEnd(encoding: String.Encoding = .utf8) throws -> String? {
+		try fileHandleForReading.readToEnd().flatMap { String(data: $0, encoding: encoding) }
+	}
+}

--- a/Sources/mas/Utilities/Process.swift
+++ b/Sources/mas/Utilities/Process.swift
@@ -1,0 +1,62 @@
+//
+// Process.swift
+// mas
+//
+// Copyright © 2025 mas-cli. All rights reserved.
+//
+
+internal import Foundation
+private import ObjectiveC
+
+func run(
+	_ executablePath: String,
+	_ args: String...,
+	errorMessage: @autoclosure () -> String,
+	runProcess run: (Process) throws -> Void = { try $0.run() },
+) async throws -> (standardOutputString: String, standardErrorString: String) {
+	let process = Process()
+	process.executableURL = URL(filePath: executablePath, directoryHint: .notDirectory)
+	process.arguments = args
+
+	let standardOutputPipe = Pipe()
+	let standardErrorPipe = Pipe()
+
+	process.standardOutput = standardOutputPipe
+	process.standardError = standardErrorPipe
+
+	let standardOutputTask = Task(priority: .background) {
+		try standardOutputPipe.readToEnd()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+	}
+	let standardErrorTask = Task(priority: .background) {
+		try standardErrorPipe.readToEnd()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+	}
+
+	do {
+		try run(process)
+	} catch {
+		throw MASError.error(errorMessage(), error: error)
+	}
+	process.waitUntilExit()
+
+	let standardOutputString = try await standardOutputTask.value
+	let standardErrorString = try await standardErrorTask.value
+
+	guard process.terminationStatus == 0 else {
+		throw MASError.error(
+			"""
+			\(errorMessage())
+			Exit status: \(process.terminationStatus)\
+			\(standardOutputString.ifNotEmptyPrepend("\n\nStandard output:\n"))\
+			\(standardErrorString.ifNotEmptyPrepend("\n\nStandard error:\n"))
+			""",
+		)
+	}
+
+	return (standardOutputString, standardErrorString)
+}
+
+private extension String {
+	func ifNotEmptyPrepend(_ prefix: String) -> Self {
+		isEmpty ? self : prefix + self
+	}
+}

--- a/Tests/MASTests/Utilities/Consequences.swift
+++ b/Tests/MASTests/Utilities/Consequences.swift
@@ -6,6 +6,7 @@
 //
 
 internal import Foundation
+@testable private import mas
 
 struct Consequences<Value> {
 	let value: Value?
@@ -88,11 +89,8 @@ private struct StandardStreamCapture { // swiftlint:disable:this one_declaration
 		close(outDuplicateFD)
 		close(errDuplicateFD)
 
-		return ( // swiftlint:disable:next force_try
-			try! outPipe.fileHandleForReading.readToEnd().flatMap { String(data: $0, encoding: encoding) } ?? "",
-			try! errPipe.fileHandleForReading.readToEnd().flatMap { String(data: $0, encoding: encoding) } ?? "",
-		) // swiftlint:disable:previous force_try
-	}
+		return (try! outPipe.readToEnd(encoding: encoding) ?? "", try! errPipe.readToEnd(encoding: encoding) ?? "")
+	} // swiftlint:disable:previous force_try
 }
 
 enum NoValue: Equatable { // swiftlint:disable:this one_declaration_per_file


### PR DESCRIPTION
Fix installer output parsing deadlock:

Read stdout & stderr of external processes concurrently with the execution of the external process to prevent deadlocks from full buffers.

Resolve #1102