### PR TITLE
Remove unnecessary `MAS.` &  `mas.`

### DIFF
--- a/Sources/mas/Commands/Config.swift
+++ b/Sources/mas/Commands/Config.swift
@@ -19,14 +19,14 @@ extension MAS {
 		func run() {
 			printer.info(
 				"""
-				mas ▁▁▁▁ \(MAS.version)
+				mas ▁▁▁▁ \(version)
 				slice ▁▁ \(runningSliceArchitecture)
 				slices ▁ \(supportedSliceArchitectures.joined(separator: " "))
-				dist ▁▁▁ \(MAS.distribution)
-				origin ▁ \(MAS.gitOrigin)
-				rev ▁▁▁▁ \(MAS.gitRevision)
-				swift ▁▁ \(MAS.swiftVersion)
-				driver ▁ \(MAS.swiftDriverVersion)
+				dist ▁▁▁ \(distribution)
+				origin ▁ \(gitOrigin)
+				rev ▁▁▁▁ \(gitRevision)
+				swift ▁▁ \(swiftVersion)
+				driver ▁ \(swiftDriverVersion)
 				store ▁▁ \(appStoreRegion)
 				region ▁ \(macRegion)
 				macos ▁▁ \(

--- a/Sources/mas/Commands/MAS.swift
+++ b/Sources/mas/Commands/MAS.swift
@@ -36,7 +36,7 @@ struct MAS: AsyncParsableCommand, Sendable {
 	static let printer = Printer()
 
 	static var _errorPrefix: String { // swiftlint:disable:this identifier_name
-		"\(mas.format(prefix: "\(errorPrefix)", format: errorFormat, for: FileHandle.standardError)) "
+		"\(format(prefix: "\(errorPrefix)", format: errorFormat, for: FileHandle.standardError)) "
 	}
 
 	private static func main() async { // swiftlint:disable:this unused_declaration

--- a/Sources/mas/Commands/Outdated.swift
+++ b/Sources/mas/Commands/Outdated.swift
@@ -49,7 +49,7 @@ extension MAS {
 			}
 
 			let format = "%\(maxADAMIDLength)lu  %@  (%@ -> %@)"
-			MAS.printer.info(
+			printer.info(
 				outdatedApps.map { installedApp, newVersion in
 					unsafe String(
 						format: format,

--- a/Sources/mas/Commands/Version.swift
+++ b/Sources/mas/Commands/Version.swift
@@ -15,7 +15,7 @@ extension MAS {
 		)
 
 		func run() {
-			printer.info(MAS.version)
+			printer.info(version)
 		}
 	}
 }


### PR DESCRIPTION
Remove unnecessary `MAS.` &  `mas.`.

Resolve #1171