### PR TITLE
Fix additional trailing zeros being counted as version upgrade

### DIFF
--- a/Sources/mas/Utilities/Collection.swift
+++ b/Sources/mas/Utilities/Collection.swift
@@ -6,6 +6,12 @@
 //
 
 extension Collection {
+	func dropLast(while predicate: (Element) throws -> Bool) rethrows -> SubSequence {
+		try indices.reversed().first { try !predicate(self[$0]) }.map { self[...$0] } ?? self[endIndex...]
+	}
+}
+
+extension Collection {
 	func compactMap<T, E: Error>(_ transform: (Element) async throws(E) -> T?) async throws(E) -> [T] {
 		var transformedElements = [T]()
 		transformedElements.reserveCapacity(count)

--- a/Sources/mas/Utilities/Version+SemVer.swift
+++ b/Sources/mas/Utilities/Version+SemVer.swift
@@ -157,16 +157,6 @@ struct UniversalSemVer: SemVerSyntax {
 	}
 }
 
-extension Collection {
-	func dropLast(while predicate: (Element) throws -> Bool) rethrows -> SubSequence {
-		guard let index = try indices.reversed().first(where: { try !predicate(self[$0]) }) else {
-			return self[startIndex..<startIndex]
-		}
-		return self[...index]
-	}
-}
-
-
 private extension BigInt {
 	func compare(to that: Self) -> ComparisonResult {
 		self < that ? .orderedAscending : self == that ? .orderedSame : .orderedDescending
@@ -196,11 +186,8 @@ private extension String {
 
 private extension [String] {
 	func compareSemVerElements(to that: Self) -> ComparisonResult {
-		zip(self, that)
-			.first { $0 != $1 }
-			.map { $0.compareSemVerElement(to: $1) }
-		?? dropLast(while: { $0 == "0" }).count
-			.compare(to: that.dropLast(while: { $0 == "0" }).count)
+		zip(self, that).first { $0 != $1 }.map { $0.compareSemVerElement(to: $1) }
+		?? dropLast { $0 == "0" }.count.compare(to: that.dropLast { $0 == "0" }.count) // swiftformat:disable:this indent
 	}
 }
 


### PR DESCRIPTION
I met the following case:
<img width="500" alt="scenario" src="https://github.com/user-attachments/assets/69b87172-4333-4551-9c1b-d33ca8e55546" />

This PR fixes this by omitting the trailing zeros during version comparison if all the other digits are equal.

Resolve #1176

> [!NOTE]
> The `dropLast` implementation comes from here: https://stackoverflow.com/a/62306093/12070367