### PR TITLE
Create temp folders for pkg installer & receipt hard links on same volume as original files

### DIFF
--- a/Sources/mas/AppStore/AppStoreAction+download.swift
+++ b/Sources/mas/AppStore/AppStoreAction+download.swift
@@ -287,7 +287,7 @@ private actor DownloadQueueObserver: CKDownloadQueueObserver {
 		let hardLinkURL = try fileManager.url(
 			for: .itemReplacementDirectory,
 			in: .userDomainMask,
-			appropriateFor: URL.homeDirectory,
+			appropriateFor: url,
 			create: true,
 		)
 		.appending(path: "\(adamID)-\(url.lastPathComponent)", directoryHint: .notDirectory)


### PR DESCRIPTION
Create temp folders for pkg installer & receipt hard links on same volume as original files.

Resolve #1186