### PR TITLE
Create receipt & ancestor folders with correct owner, group & permissions

### DIFF
--- a/Sources/mas/AppStore/AppStoreAction+download.swift
+++ b/Sources/mas/AppStore/AppStoreAction+download.swift
@@ -305,10 +305,9 @@ private actor DownloadQueueObserver: CKDownloadQueueObserver {
 					}
 				} else {
 					MAS.printer.warning(
+						action.performed.capitalizingFirstCharacter,
 						snapshot.appNameAndVersion,
-						"was",
-						action.performed,
-						"outside of the applications folders:",
+						"outside of the applications folders, in",
 						appFolderURL.filePath,
 					)
 				}


### PR DESCRIPTION
Create receipt & ancestor folders with correct owner, group & permissions.

Improve modified app outside of applications folders warning.

Resolve #1177