### PR TITLE
Fix `--no-check-min-os` for inaccurate outdated app detection

### DIFF
--- a/Sources/mas/Models/OutdatedApp.swift
+++ b/Sources/mas/Models/OutdatedApp.swift
@@ -17,70 +17,75 @@ typealias OutdatedApp = (
 
 extension [InstalledApp] {
 	func outdatedApps(
-		filterFor appIDs: [AppID],
+		filterFor appIDs: [AppID], // swiftlint:disable:next unneeded_escaping
 		lookupAppFromAppID: @escaping @Sendable (AppID) async throws -> CatalogApp,
 		accuracy: OutdatedAccuracy,
 		shouldCheckMinimumOSVersion: Bool,
 		shouldWarnIfUnknownApp: Bool,
 	) async -> [OutdatedApp] {
-		await filter(for: appIDs).concurrentCompactMap { installedApp in
-			if shouldCheckMinimumOSVersion || accuracy == .inaccurate {
-				do {
-					let catalogApp = try await lookupAppFromAppID(.bundleID(installedApp.bundleID))
-					if
-						UniversalSemVerInt(from: catalogApp.minimumOSVersion).flatMap({ minimumOSVersion in
-							ProcessInfo.processInfo.isOperatingSystemAtLeast(
-								OperatingSystemVersion(
-									majorVersion: minimumOSVersion.majorInteger,
-									minorVersion: minimumOSVersion.minorInteger,
-									patchVersion: minimumOSVersion.patchInteger,
-								),
-							)
-						})
-						== false
-					{
-						return nil
-					}
-					if accuracy == .inaccurate {
-						return UniversalSemVer(from: installedApp.version)
-						.compareSemVerAndBuild(to: .init(from: catalogApp.version)) // swiftformat:disable:this indent
-						== .orderedAscending ? OutdatedApp(installedApp, catalogApp.version) : nil
-					} // swiftformat:disable:previous indent
-				} catch {
-					if let error = error as? MASError, case MASError.unknownAppID = error {
-						if shouldWarnIfUnknownApp {
-							MAS.printer.warning(error, "; was expected to identify: ", installedApp.name, separator: "")
-						}
-					} else {
-						MAS.printer.error(error: error)
-					}
-
-					return nil
+		@Sendable
+		func installableCatalogApp(from installedApp: InstalledApp) async -> CatalogApp? {
+			do {
+				let catalogApp = try await lookupAppFromAppID(.bundleID(installedApp.bundleID))
+				return shouldCheckMinimumOSVersion // swiftformat:disable indent
+				&& UniversalSemVerInt(from: catalogApp.minimumOSVersion).flatMap { minimumOSVersion in
+					ProcessInfo.processInfo.isOperatingSystemAtLeast(
+						OperatingSystemVersion(
+							majorVersion: minimumOSVersion.majorInteger,
+							minorVersion: minimumOSVersion.minorInteger,
+							patchVersion: minimumOSVersion.patchInteger,
+						),
+					)
 				}
-			}
-			return await withCheckedContinuation { continuation in
-				Task {
-					let alreadyResumed = ManagedAtomic(false)
-					do {
-						try await AppStore.install.app(withADAMID: installedApp.adamID) { appStoreVersion, shouldOutput in
-							if
-								shouldOutput,
-								let appStoreVersion,
-								installedApp.version != appStoreVersion,
-								!alreadyResumed.exchange(true, ordering: .acquiringAndReleasing)
-							{
-								continuation.resume(returning: OutdatedApp(installedApp, appStoreVersion))
-							}
-							return true
-						}
-					} catch {
-						MAS.printer.error(error: error)
+				== false ? nil : catalogApp
+			} catch { // swiftformat:enable indent
+				if let error = error as? MASError, case MASError.unknownAppID = error {
+					if shouldWarnIfUnknownApp {
+						MAS.printer.warning(error, "; was expected to identify: ", installedApp.name, separator: "")
 					}
-					if !alreadyResumed.load(ordering: .acquiring) {
-						continuation.resume(returning: nil)
-					}
+				} else {
+					MAS.printer.error(error: error)
 				}
+				return nil
 			}
 		}
+
+		return await filter(for: appIDs).concurrentCompactMap(
+			accuracy == .accurate
+			? { @Sendable installedApp in // swiftformat:disable indent
+				if shouldCheckMinimumOSVersion, await installableCatalogApp(from: installedApp) == nil {
+					return nil
+				}
+				return await withCheckedContinuation { continuation in
+					Task {
+						let alreadyResumed = ManagedAtomic(false)
+						do {
+							try await AppStore.install.app(withADAMID: installedApp.adamID) { appStoreVersion, shouldOutput in
+								if
+									shouldOutput,
+									let appStoreVersion,
+									installedApp.version != appStoreVersion,
+									!alreadyResumed.exchange(true, ordering: .acquiringAndReleasing)
+								{
+									continuation.resume(returning: OutdatedApp(installedApp, appStoreVersion))
+								}
+								return true
+							}
+						} catch {
+							MAS.printer.error(error: error)
+						}
+						if !alreadyResumed.load(ordering: .acquiring) {
+							continuation.resume(returning: nil)
+						}
+					}
+				}
+			}
+			: { @Sendable installedApp in
+				await installableCatalogApp(from: installedApp).flatMap { catalogApp in
+					UniversalSemVer(from: installedApp.version).compareSemVerAndBuild(to: .init(from: catalogApp.version))
+					== .orderedAscending ? OutdatedApp(installedApp, catalogApp.version) : nil
+				}
+			},
+		) // swiftformat:enable indent
 	}
 }


### PR DESCRIPTION
Fix `--no-check-min-os` for inaccurate outdated app detection.

Resolve #1213