### PR TITLE
Add ls alias for list command

### DIFF
--- a/Sources/mas/Commands/List.swift
+++ b/Sources/mas/Commands/List.swift
@@ -13,6 +13,7 @@ extension MAS {
 	struct List: AsyncParsableCommand {
 		static let configuration = CommandConfiguration(
 			abstract: "List apps installed from the App Store",
+			aliases: ["ls"],
 		)
 
 		@OptionGroup


### PR DESCRIPTION
## Summary
- add ls as an alias for the list command
- make mas ls behave the same as mas list

## Validation
- swift build