### PR TITLE
Avoid warnings from Homebrew in `build-test.yaml`

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -50,7 +50,9 @@ jobs:
         echo "DEVELOPER_DIR=${XCODE_PATH}/Contents/Developer" >>"${GITHUB_ENV}"
 
     - name: 👢 Bootstrap
-      run: Scripts/bootstrap
+      run: |
+        brew untap -fq aws/tap 2>/dev/null || true
+        Scripts/bootstrap
 
     - name: 🕊 Use Swiftly Swift
       if: ${{!startsWith(matrix.runner, 'macos-26')}}

--- a/Scripts/bootstrap
+++ b/Scripts/bootstrap
@@ -21,7 +21,7 @@ fi
 brew update -q
 installed_formulae=("${(f)$(brew list --formulae)}")
 readonly -a installed_formulae
-bootstrap_formulae=("${(f)$(brew deps --union "${(f)$(brew bundle list --formulae)}")}")
+bootstrap_formulae=("${(f)$(HOMEBREW_NO_ENV_HINTS=1 brew deps --union "${(f)$(brew bundle list --formulae)}")}")
 readonly -a bootstrap_formulae
 # shellcheck disable=SC2086
 (("${#installed_formulae:*bootstrap_formulae}")) &&


### PR DESCRIPTION
Avoid warnings from Homebrew in `build-test.yaml`.

Resolve #1281