### PR TITLE
Output actual App Store name of an installed app

### DIFF
--- a/Sources/mas/Models/InstalledApp.swift
+++ b/Sources/mas/Models/InstalledApp.swift
@@ -28,20 +28,36 @@ struct InstalledApp {
 		lazyJSONObject.value
 	}
 
-	fileprivate init(for valueByAttribute: [String: Any]) {
-		adamID = valueByAttribute["kMDItemAppStoreAdamID"] as? ADAMID ?? 0
-		bundleID = .init(describing: valueByAttribute[NSMetadataItemCFBundleIdentifierKey] ?? "")
-		name = .init(describing: valueByAttribute["_kMDItemDisplayNameWithExtensions"] ?? "").removingSuffix(".app")
-		path = valueByAttribute[NSMetadataItemPathKey].map { pathAny in
-			let path = String(describing: pathAny)
-			return (try? URL(folderPath: path).resourceValues(forKeys: [.canonicalPathKey]))?.canonicalPath ?? path
-		}
-			?? ""
-		version = .init(describing: valueByAttribute[NSMetadataItemVersionKey] ?? "")
+	init(for valueByAttribute: [String: Any]) {
+		self.init(
+			adamID: valueByAttribute["kMDItemAppStoreAdamID"] as? ADAMID ?? 0,
+			bundleID: .init(describing: valueByAttribute[NSMetadataItemCFBundleIdentifierKey] ?? ""),
+			name: .init(describing: valueByAttribute["_kMDItemDisplayNameWithExtensions"] ?? "").removingSuffix(".app"),
+			path: valueByAttribute[NSMetadataItemPathKey].map { pathAny in
+				let path = String(describing: pathAny)
+				return (try? URL(folderPath: path).resourceValues(forKeys: [.canonicalPathKey]))?.canonicalPath ?? path
+			}
+				?? "",
+			version: .init(describing: valueByAttribute[NSMetadataItemVersionKey] ?? ""),
+			jsonObjectRaw: .init(valueByAttribute.map { (.init(rawValue: $0.key), .init(for: $0.value)) }),
+		)
+	}
 
-		jsonObjectRaw = .init(valueByAttribute.map { (.init(rawValue: $0.key), .init(for: $0.value)) })
-		let jsonObjectRaw = jsonObjectRaw
-		let name = name
+	private init(
+		adamID: ADAMID,
+		bundleID: String,
+		name: String,
+		path: String,
+		version: String,
+		jsonObjectRaw: JSON.Object,
+	) {
+		self.adamID = adamID
+		self.bundleID = bundleID
+		self.name = name
+		self.path = path
+		self.version = version
+
+		self.jsonObjectRaw = jsonObjectRaw
 		lazyJSONObject = .init(
 			.init(
 				(jsonObjectRaw.fields.map { ($0.normalized, $1) } + [("name", .string(name))])
@@ -60,11 +76,40 @@ struct InstalledApp {
 			self.bundleID == bundleID
 		}
 	}
+
+	fileprivate func named(_ name: String) -> Self {
+		.init(adamID: adamID, bundleID: bundleID, name: name, path: path, version: version, jsonObjectRaw: jsonObjectRaw)
+	}
 }
 
 extension InstalledApp: CustomStringConvertible {
 	var description: String {
 		lazyJSON.value
+	}
+}
+
+extension [InstalledApp] {
+	/// Replaces each app's Spotlight-derived name with its exact App Store name.
+	///
+	/// Neither Spotlight nor `Info.plist` records the App Store name, so both
+	/// only approximate it; e.g., "WFMU Radio" (324175340) is named "WFMU" in
+	/// both. Apps that the App Store does not know about, such as TestFlight
+	/// apps, keep their approximated names.
+	var withCatalogNames: Self {
+		get async {
+			let lookupAppFromAppID = Environment.current.lookupAppFromAppID
+			return await concurrentMap { installedApp in
+				guard
+					installedApp.adamID != 0,
+					let catalogName = try? await lookupAppFromAppID(.adamID(installedApp.adamID)).name,
+					!catalogName.isEmpty
+				else {
+					return installedApp
+				}
+
+				return installedApp.named(catalogName)
+			}
+		}
 	}
 }
 
@@ -304,6 +349,7 @@ func installedApps(
 
 func installedApps(matching appIDs: [AppID], withFullJSON: Bool) async -> [InstalledApp] {
 	await unsortedInstalledApps(matching: appIDs, withFullJSON: withFullJSON)
+		.withCatalogNames
 		.sorted(using: KeyPathComparator(\.name, comparator: .localizedStandard))
 }
 

--- a/Sources/mas/Utilities/Swift/Collection.swift
+++ b/Sources/mas/Utilities/Swift/Collection.swift
@@ -6,10 +6,10 @@
 //
 
 extension Collection where Element: Sendable {
-	func concurrentMap<T: Sendable>( // swiftlint:disable:this unused_declaration
+	func concurrentMap<T: Sendable>(
 		maxConcurrentTaskCount: Int = defaultMaxConcurrentTaskCount,
 		_ transform: @escaping @Sendable (Element) async -> T,
-	) async -> [T] { // periphery:ignore
+	) async -> [T] {
 		await concurrentTransform(maxConcurrentTaskCount: maxConcurrentTaskCount, transform)
 	}
 

--- a/Tests/MASTests/Models/MASTests+InstalledApp.swift
+++ b/Tests/MASTests/Models/MASTests+InstalledApp.swift
@@ -1,0 +1,64 @@
+//
+// MASTests+InstalledApp.swift
+// mas
+//
+// Copyright © 2026 mas-cli. All rights reserved.
+//
+
+private import Foundation
+@testable private import mas
+internal import Testing
+
+private extension MASTests {
+	@Test
+	func `uses App Store name for installed app`() async throws {
+		let catalogApp = try decode(CatalogApp.self, fromResource: "things-lookup")
+		let actual = try await consequencesOf(
+			await Environment.$current.withValue(environment { _ in catalogApp }) {
+				await [InstalledApp(for: installedThingsAttributes())].withCatalogNames.first?.name
+			},
+		)
+		let expected = Consequences("Things That Go Bump")
+		#expect(actual == expected)
+	}
+
+	@Test
+	func `falls back to approximated name of installed app unknown to App Store`() async throws {
+		let actual = try await consequencesOf(
+			await Environment.$current.withValue(environment { throw MASError.unknownAppID($0) }) {
+				await [InstalledApp(for: installedThingsAttributes())].withCatalogNames.first?.name
+			},
+		)
+		let expected = Consequences("Things That Go Bmup")
+		#expect(actual == expected)
+	}
+
+	@Test
+	func `keeps approximated name of installed app without an ADAM ID`() async throws {
+		let catalogApp = try decode(CatalogApp.self, fromResource: "things-lookup")
+		let actual = try await consequencesOf(
+			await Environment.$current.withValue(environment { _ in catalogApp }) {
+				await [InstalledApp(for: installedThingsAttributes(adamID: 0))].withCatalogNames.first?.name
+			},
+		)
+		let expected = Consequences("Things That Go Bmup")
+		#expect(actual == expected)
+	}
+}
+
+private func environment(
+	lookingUpAppFromAppID lookupAppFromAppID: @escaping @Sendable (AppID) async throws -> CatalogApp,
+) -> Environment {
+	.init(lookupAppFromAppID: lookupAppFromAppID)
+}
+
+private func installedThingsAttributes(adamID: ADAMID = 1_472_954_003) -> [String: Any] {
+	[
+		"kMDItemAppStoreAdamID": adamID,
+		NSMetadataItemCFBundleIdentifierKey: "uikitformac.com.tinybop.thingamabops",
+		// Deliberately misspelled to distinguish the approximated name from the App Store name
+		"_kMDItemDisplayNameWithExtensions": "Things That Go Bmup.app",
+		NSMetadataItemPathKey: "/Applications/Things That Go Bmup.app",
+		NSMetadataItemVersionKey: "1.3.0",
+	]
+}


### PR DESCRIPTION
## Summary

Fixes #784. `InstalledApp` derived `name` solely from the Spotlight attribute `_kMDItemDisplayNameWithExtensions`, which records an app bundle's on-disk name rather than its App Store name. Neither Spotlight nor `Info.plist` records the App Store name, so the output name was only an approximation — e.g. "WFMU Radio" (adamID 324175340) was output as just "WFMU".

## Fix

Resolves each installed app's name via the iTunes Search API instead, reusing the existing `Environment.lookupAppFromAppID` abstraction that `mas lookup` and `mas outdated` already use, rather than adding a new HTTP call. Lookups run concurrently via the existing `concurrentMap`.

- Apps the App Store doesn't know about (e.g. TestFlight apps) or whose lookup fails (e.g. offline) keep their approximated name — this is a best-effort upgrade, not a hard requirement.
- `InstalledApp.init(for:)` has to stay synchronous, so the resolved name is applied afterward, in `installedApps(matching:withFullJSON:)`, before apps are sorted by name.
- `concurrentMap`'s `unused_declaration`/`periphery:ignore` suppressions are removed since it's no longer unused.

## Test plan

Added `Tests/MASTests/Models/MASTests+InstalledApp.swift` with 3 cases, following the existing test suite's conventions (fixture-based `Environment.$current.withValue` injection):
- Uses the App Store name when the lookup succeeds
- Falls back to the approximated name when the lookup throws (e.g. offline)
- Keeps the approximated name when there's no ADAM ID (app not from the App Store)

`swift build` succeeds cleanly. I could not run `swift test` in my environment — it fails with `error: no such module 'Testing'` (the Swift Testing framework), but I confirmed this is a pre-existing environment limitation and not something this change introduced: the same error occurs on a clean checkout of `main` with no changes at all. I don't have a full Xcode install available, only Command Line Tools, which appears to be the gap. Happy to have CI confirm the test suite, or take pointers on getting Testing available locally.